### PR TITLE
Initial support for patching PS3 consoles

### DIFF
--- a/Refresher.sln.DotSettings
+++ b/Refresher.sln.DotSettings
@@ -24,4 +24,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reverify/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RFSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RPCS/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=USRDIR/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=USRDIR/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=webman/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Refresher/Accessors/ConsolePatchAccessor.cs
+++ b/Refresher/Accessors/ConsolePatchAccessor.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using FluentFTP;
+
+namespace Refresher.Accessors;
+
+public class ConsolePatchAccessor : PatchAccessor, IDisposable
+{
+    private readonly FtpClient _client;
+    private const string BasePath = "/dev_hdd0/";
+
+    public ConsolePatchAccessor(string remoteIp)
+    {
+        this._client = new FtpClient(remoteIp, "anonymous", "");
+        this._client.Config.LogToConsole = true;
+        this._client.AutoConnect();
+    }
+    
+    private string GetPath(string path)
+    {
+        if (Path.IsPathRooted(path)) return path;
+        return BasePath + path;
+    }
+
+    public override bool DirectoryExists(string path) => this._client.DirectoryExists(this.GetPath(path));
+
+    public override bool FileExists(string path) => this._client.FileExists(this.GetPath(path));
+
+    public override IEnumerable<string> GetDirectoriesInDirectory(string path) =>
+        this._client.GetListing(this.GetPath(path))
+            .Where(l => l.Type == FtpObjectType.Directory)
+            .Select(l => l.FullName);
+
+    public override IEnumerable<string> GetFilesInDirectory(string path) =>
+        this._client.GetListing(this.GetPath(path))
+            .Where(l => l.Type == FtpObjectType.File)
+            .Select(l => l.FullName);
+
+    public override Stream OpenRead(string path)
+    {
+        MemoryStream ms = new();
+        this._client.DownloadStream(ms, this.GetPath(path));
+        ms.Seek(0, SeekOrigin.Begin);
+        return ms;
+        
+        // technically we can use a stream directly but this uses a lot more requests
+        // and webman doesnt like that
+        return this._client.OpenRead(this.GetPath(path));
+    }
+
+    public override Stream OpenWrite(string path)
+    {
+        return this._client.OpenWrite(this.GetPath(path));
+    }
+
+    public void Dispose()
+    {
+        this._client.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Refresher/Accessors/ConsolePatchAccessor.cs
+++ b/Refresher/Accessors/ConsolePatchAccessor.cs
@@ -15,42 +15,40 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
         this._client.AutoConnect();
     }
     
-    private string GetPath(string path)
+    private static string GetPath(string path)
     {
         if (Path.IsPathRooted(path)) return path;
         return BasePath + path;
     }
 
-    public override bool DirectoryExists(string path) => this._client.DirectoryExists(this.GetPath(path));
+    public override bool DirectoryExists(string path) => this._client.DirectoryExists(GetPath(path));
 
-    public override bool FileExists(string path) => this._client.FileExists(this.GetPath(path));
+    public override bool FileExists(string path) => this._client.FileExists(GetPath(path));
 
     public override IEnumerable<string> GetDirectoriesInDirectory(string path) =>
-        this._client.GetListing(this.GetPath(path))
+        this._client.GetListing(GetPath(path))
             .Where(l => l.Type == FtpObjectType.Directory)
             .Select(l => l.FullName);
 
     public override IEnumerable<string> GetFilesInDirectory(string path) =>
-        this._client.GetListing(this.GetPath(path))
+        this._client.GetListing(GetPath(path))
             .Where(l => l.Type == FtpObjectType.File)
             .Select(l => l.FullName);
 
     public override Stream OpenRead(string path)
     {
         MemoryStream ms = new();
-        this._client.DownloadStream(ms, this.GetPath(path));
+        this._client.DownloadStream(ms, GetPath(path));
         ms.Seek(0, SeekOrigin.Begin);
         return ms;
         
         // technically we can use a stream directly but this uses a lot more requests
-        // and webman doesnt like that
-        return this._client.OpenRead(this.GetPath(path));
+        // and webman doesnt like that, it tends to just slow down to a crawl after a bunch of them :(
+        // return this._client.OpenRead(GetPath(path));
     }
 
-    public override Stream OpenWrite(string path)
-    {
-        return this._client.OpenWrite(this.GetPath(path));
-    }
+    public override Stream OpenWrite(string path) => this._client.OpenWrite(GetPath(path));
+    public override void RemoveFile(string path) => this._client.DeleteFile(GetPath(path));
 
     public void Dispose()
     {

--- a/Refresher/Accessors/EmulatorPatchAccessor.cs
+++ b/Refresher/Accessors/EmulatorPatchAccessor.cs
@@ -1,0 +1,26 @@
+namespace Refresher.Accessors;
+
+public class EmulatorPatchAccessor : PatchAccessor
+{
+    public EmulatorPatchAccessor(string basePath)
+    {
+        this.BasePath = basePath;
+    }
+
+    private string BasePath { get; }
+
+    private string GetPath(string path)
+    {
+        if (Path.IsPathRooted(path)) return path;
+        return Path.Join(this.BasePath, path);
+    }
+
+    public override bool DirectoryExists(string path) => Directory.Exists(this.GetPath(path));
+    public override bool FileExists(string path) => File.Exists(this.GetPath(path));
+    
+    public override IEnumerable<string> GetDirectoriesInDirectory(string path) => Directory.GetDirectories(this.GetPath(path));
+    public override IEnumerable<string> GetFilesInDirectory(string path) => Directory.GetFiles(this.GetPath(path));
+    
+    public override Stream OpenRead(string path) => File.OpenRead(this.GetPath(path));
+    public override Stream OpenWrite(string path) => File.OpenWrite(this.GetPath(path));
+}

--- a/Refresher/Accessors/EmulatorPatchAccessor.cs
+++ b/Refresher/Accessors/EmulatorPatchAccessor.cs
@@ -23,4 +23,8 @@ public class EmulatorPatchAccessor : PatchAccessor
     
     public override Stream OpenRead(string path) => File.OpenRead(this.GetPath(path));
     public override Stream OpenWrite(string path) => File.OpenWrite(this.GetPath(path));
+    public override void RemoveFile(string path) => File.Delete(this.GetPath(path));
+
+    public override void DuplicateFile(string inPath, string outPath)
+        => File.Copy(this.GetPath(inPath), this.GetPath(outPath));
 }

--- a/Refresher/Accessors/PatchAccessor.cs
+++ b/Refresher/Accessors/PatchAccessor.cs
@@ -27,20 +27,4 @@ public abstract class PatchAccessor
         
         inStream.CopyTo(outStream);
     }
-    
-    public string DownloadDirectory(string path)
-    {
-        string outDir = Path.Join(Path.GetTempPath(), "refresher-" + Random.Shared.Next());
-        Directory.CreateDirectory(outDir);
-        
-        IEnumerable<string> files = this.GetFilesInDirectory(path);
-        foreach (string filePath in files)
-        {
-            using FileStream outStream = File.OpenWrite(Path.Join(outDir, Path.GetFileName(filePath)));
-            using Stream inStream = this.OpenRead(filePath);
-            inStream.CopyTo(outStream);
-        }
-
-        return outDir;
-    }
 }

--- a/Refresher/Accessors/PatchAccessor.cs
+++ b/Refresher/Accessors/PatchAccessor.cs
@@ -1,0 +1,46 @@
+namespace Refresher.Accessors;
+
+public abstract class PatchAccessor
+{
+    public abstract bool DirectoryExists(string path);
+    public abstract bool FileExists(string path);
+    public abstract IEnumerable<string> GetDirectoriesInDirectory(string path);
+    public abstract IEnumerable<string> GetFilesInDirectory(string path);
+    public abstract Stream OpenRead(string path);
+    public abstract Stream OpenWrite(string path);
+
+    public string DownloadFile(string path)
+    {
+        string outFile = Path.GetTempFileName();
+        
+        using FileStream outStream = File.OpenWrite(outFile);
+        using Stream inStream = this.OpenRead(path);
+        inStream.CopyTo(outStream);
+
+        return outFile;
+    }
+
+    public void UploadFile(string inPath, string outPath)
+    {
+        using FileStream inStream = File.OpenRead(inPath);
+        using Stream outStream = this.OpenWrite(outPath);
+        
+        inStream.CopyTo(outStream);
+    }
+    
+    public string DownloadDirectory(string path)
+    {
+        string outDir = Path.Join(Path.GetTempPath(), "refresher-" + Random.Shared.Next());
+        Directory.CreateDirectory(outDir);
+        
+        IEnumerable<string> files = this.GetFilesInDirectory(path);
+        foreach (string filePath in files)
+        {
+            using FileStream outStream = File.OpenWrite(Path.Join(outDir, Path.GetFileName(filePath)));
+            using Stream inStream = this.OpenRead(filePath);
+            inStream.CopyTo(outStream);
+        }
+
+        return outDir;
+    }
+}

--- a/Refresher/Accessors/PatchAccessor.cs
+++ b/Refresher/Accessors/PatchAccessor.cs
@@ -8,6 +8,7 @@ public abstract class PatchAccessor
     public abstract IEnumerable<string> GetFilesInDirectory(string path);
     public abstract Stream OpenRead(string path);
     public abstract Stream OpenWrite(string path);
+    public abstract void RemoveFile(string path);
 
     public string DownloadFile(string path)
     {
@@ -23,6 +24,14 @@ public abstract class PatchAccessor
     public void UploadFile(string inPath, string outPath)
     {
         using FileStream inStream = File.OpenRead(inPath);
+        using Stream outStream = this.OpenWrite(outPath);
+        
+        inStream.CopyTo(outStream);
+    }
+
+    public virtual void DuplicateFile(string inPath, string outPath)
+    {
+        using Stream inStream = this.OpenRead(inPath);
         using Stream outStream = this.OpenWrite(outPath);
         
         inStream.CopyTo(outStream);

--- a/Refresher/Patching/Patcher.cs
+++ b/Refresher/Patching/Patcher.cs
@@ -21,7 +21,7 @@ public partial class Patcher
 
         this.Stream.Position = 0;
 
-        this._targets = new(() => FindPatchableElements(stream));
+        this._targets = new Lazy<List<PatchTargetInfo>>(() => FindPatchableElements(stream));
     }
 
     public Stream Stream { get; }

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -22,7 +22,7 @@
       <EmbeddedResource Include="Resources\refresher.ico" LogicalName="refresher.ico" />
       <PackageReference Include="FluentFTP" Version="47.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="SCEToolSharp" Version="1.0.7" />
+      <PackageReference Include="SCEToolSharp" Version="1.0.8" />
     </ItemGroup>
 
 

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -20,6 +20,7 @@
       <PackageReference Include="Eto.Platform.Gtk" Version="2.7.5" />
       <PackageReference Condition="'$(TargetFramework)' == 'net7.0-windows'" Include="Eto.Platform.Windows" Version="2.7.5" />
       <EmbeddedResource Include="Resources\refresher.ico" LogicalName="refresher.ico" />
+      <PackageReference Include="FluentFTP" Version="47.1.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="SCEToolSharp" Version="1.0.7" />
     </ItemGroup>

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -24,4 +24,5 @@
       <PackageReference Include="SCEToolSharp" Version="1.0.7" />
     </ItemGroup>
 
+
 </Project>

--- a/Refresher/UI/ConsolePatchForm.cs
+++ b/Refresher/UI/ConsolePatchForm.cs
@@ -22,4 +22,7 @@ public class ConsolePatchForm : IntegratedPatchForm
     {
         return AddField("PS3's IP", out this._remoteAddress);
     }
+
+    protected override bool NeedsResign => true;
+    protected override bool ShouldReplaceExecutable => true;
 }

--- a/Refresher/UI/ConsolePatchForm.cs
+++ b/Refresher/UI/ConsolePatchForm.cs
@@ -1,0 +1,25 @@
+using Eto.Forms;
+using Refresher.Accessors;
+
+namespace Refresher.UI;
+
+public class ConsolePatchForm : IntegratedPatchForm
+{
+    private TextBox _remoteAddress = null!;
+    
+    public ConsolePatchForm() : base("PS3 Patch")
+    {
+        this._remoteAddress.LostFocus += this.PathChanged;
+    }
+
+    protected override void PathChanged(object? sender, EventArgs ev)
+    {
+        this.Accessor = new ConsolePatchAccessor(this._remoteAddress.Text);
+        base.PathChanged(sender, ev);
+    }
+
+    protected override TableRow AddRemoteField()
+    {
+        return AddField("PS3's IP", out this._remoteAddress);
+    }
+}

--- a/Refresher/UI/EmulatorPatchForm.cs
+++ b/Refresher/UI/EmulatorPatchForm.cs
@@ -1,44 +1,17 @@
-using System.Diagnostics;
 using Eto;
-using Eto.Drawing;
 using Eto.Forms;
 using Refresher.Accessors;
-using Refresher.Patching;
-using Refresher.UI.Items;
-using Refresher.Verification;
-using SCEToolSharp;
 
 namespace Refresher.UI;
 
-public class EmulatorPatchForm : PatchForm<Patcher>
+public class EmulatorPatchForm : IntegratedPatchForm
 {
-    private readonly FilePicker _folderField;
-    private readonly DropDown   _gameDropdown;
-    private readonly TextBox    _outputField;
+    private FilePicker _folderField;
 
-    private string _tempFile;
-    private string _usrDir;
-
-    private EmulatorPatchAccessor? _accessor;
-
-    protected override TableLayout FormPanel { get; }
-    
     public EmulatorPatchForm() : base("RPCS3 Patch")
     {
-        this.FormPanel = new TableLayout(new List<TableRow>
-        {
-            AddField("RPCS3 dev_hdd0 folder", out this._folderField),
-            AddField("Game to patch", out this._gameDropdown),
-            AddField("Server URL", out this.UrlField),
-            AddField("Identifier (EBOOT.<value>.elf)", out this._outputField),
-        });
-
         this._folderField.FileAction = FileAction.SelectFolder;
         this._folderField.FilePathChanged += this.PathChanged;
-        
-        this._outputField.PlaceholderText = "refresh";
-
-        this._gameDropdown.SelectedValueChanged += this.GameChanged;
 
         // RPCS3 builds for Windows are portable
         // TODO: Cache the last used location for easier entry
@@ -53,100 +26,21 @@ public class EmulatorPatchForm : PatchForm<Patcher>
                 this.LogMessage("RPCS3's path has been detected automatically! You do not need to change the path.");
             }
         }
-
-        this.InitializePatcher();
-    }
-
-    private void PathChanged(object? sender, EventArgs ev)
-    {
-        string path = this._folderField.FilePath;
-        this._gameDropdown.Items.Clear();
-
-        this._accessor = new EmulatorPatchAccessor(path);
-        
-        if (!this._accessor.DirectoryExists("game")) return;
-            
-        string[] games = this._accessor.GetDirectoriesInDirectory("game").ToArray();
-        
-        foreach (string gamePath in games)
-        {
-            string game = Path.GetFileName(gamePath);
-            
-            // Example TitleID: BCUS98208, must be 9 chars
-            if(game.Length != 9) continue; // Skip over profiles/save data/other garbage
-
-            GameItem item = new();
-            
-            string iconPath = Path.Combine(gamePath, "ICON0.PNG");
-            if (this._accessor.FileExists(iconPath))
-            {
-                using Stream iconStream = this._accessor.OpenRead(iconPath);
-                item.Image = new Bitmap(iconStream).WithSize(new Size(64, 64));
-            }
-
-            string sfoPath = Path.Combine(gamePath, "PARAM.SFO");
-            try
-            {
-                using Stream sfoStream = this._accessor.OpenRead(sfoPath);
-                ParamSfo sfo = new(sfoStream);
-                item.Text = $"{sfo.Table["TITLE"]} [{game}]";
-            }
-            catch
-            {
-                item.Text = game;
-            }
-
-            item.TitleId = game;
-            
-            this._gameDropdown.Items.Add(item);
-        }
-    }
-
-    private void GameChanged(object? sender, EventArgs ev)
-    {
-        GameItem? game = this._gameDropdown.SelectedValue as GameItem;
-        Debug.Assert(game != null);
-        Debug.Assert(this._accessor != null);
-
-        this._usrDir = Path.Combine("game", game.TitleId, "USRDIR");
-        string ebootPath = this._accessor.DownloadFile(Path.Combine(this._usrDir, "EBOOT.BIN"));
-        string rapDir = this._accessor.DownloadDirectory(Path.Combine("home", "00000001", "exdata"));
-        
-        this.LogMessage($"EBOOT Path: {ebootPath}");
-        if (!this._accessor.FileExists(ebootPath))
-        {
-            this.FailVerify("Could not find the EBOOT. Patching cannot continue.", clear: false);
-            return;
-        }
-
-        this._tempFile = Path.GetTempFileName();
-        
-        LibSceToolSharp.SetRapDirectory(rapDir);
-        LibSceToolSharp.Decrypt(ebootPath, this._tempFile);
-        
-        this.LogMessage($"The EBOOT has been successfully decrypted. It's stored at {this._tempFile}.");
-        
-        this.Patcher = new Patcher(File.Open(this._tempFile, FileMode.Open, FileAccess.ReadWrite));
-
-        this.Reverify(sender, ev);
-    }
-    
-    public override void CompletePatch(object? sender, EventArgs e) {
-        Debug.Assert(this._accessor != null);
-        string identifier = string.IsNullOrWhiteSpace(this._outputField.Text) ? this._outputField.PlaceholderText : this._outputField.Text;
-        
-        string destination = Path.Combine(this._usrDir, $"EBOOT.{identifier}.elf");
-        
-        this._accessor.UploadFile(this._tempFile, destination);
-        MessageBox.Show($"Successfully patched EBOOT! It was saved to '{destination}'.");
-
-        // Re-initialize patcher so we can patch with the same parameters again
-        // Probably slow but prevents crash
-        this.GameChanged(this, EventArgs.Empty);
     }
 
     public override void Guide(object? sender, EventArgs e)
     {
         this.OpenUrl("https://littlebigrefresh.github.io/Docs/patching/rpcs3");
+    }
+
+    protected override void PathChanged(object? sender, EventArgs ev)
+    {
+        this.Accessor = new EmulatorPatchAccessor(this._folderField.FilePath);
+        base.PathChanged(sender, ev);
+    }
+
+    protected override TableRow AddRemoteField()
+    {
+        return AddField("RPCS3 dev_hdd0 folder", out this._folderField);
     }
 }

--- a/Refresher/UI/EmulatorPatchForm.cs
+++ b/Refresher/UI/EmulatorPatchForm.cs
@@ -6,7 +6,7 @@ namespace Refresher.UI;
 
 public class EmulatorPatchForm : IntegratedPatchForm
 {
-    private FilePicker _folderField;
+    private FilePicker _folderField = null!;
 
     public EmulatorPatchForm() : base("RPCS3 Patch")
     {

--- a/Refresher/UI/EmulatorPatchForm.cs
+++ b/Refresher/UI/EmulatorPatchForm.cs
@@ -43,4 +43,7 @@ public class EmulatorPatchForm : IntegratedPatchForm
     {
         return AddField("RPCS3 dev_hdd0 folder", out this._folderField);
     }
+
+    protected override bool NeedsResign => false;
+    protected override bool ShouldReplaceExecutable => false;
 }

--- a/Refresher/UI/IntegratedPatchForm.cs
+++ b/Refresher/UI/IntegratedPatchForm.cs
@@ -1,0 +1,128 @@
+using System.Diagnostics;
+using Eto.Drawing;
+using Eto.Forms;
+using Refresher.Accessors;
+using Refresher.Patching;
+using Refresher.UI.Items;
+using Refresher.Verification;
+using SCEToolSharp;
+
+namespace Refresher.UI;
+
+public abstract class IntegratedPatchForm : PatchForm<Patcher>
+{
+    private readonly DropDown _gameDropdown;
+    private readonly TextBox _outputField;
+    
+    private string _tempFile;
+    private string _usrDir;
+
+    protected PatchAccessor? Accessor;
+    
+    protected override TableLayout FormPanel { get; }
+    
+    protected IntegratedPatchForm(string subtitle) : base(subtitle)
+    {
+        this.FormPanel = new TableLayout(new List<TableRow>
+        {
+            // ReSharper disable once VirtualMemberCallInConstructor
+            this.AddRemoteField(),
+            AddField("Game to patch", out this._gameDropdown),
+            AddField("Server URL", out this.UrlField),
+            AddField("Identifier (EBOOT.<value>.elf)", out this._outputField),
+        });
+        
+        this._outputField.PlaceholderText = "refresh";
+        this._gameDropdown.SelectedValueChanged += this.GameChanged;
+        
+        this.InitializePatcher();
+    }
+    
+    protected virtual void PathChanged(object? sender, EventArgs ev)
+    {
+        Debug.Assert(this.Accessor != null);
+        this._gameDropdown.Items.Clear();
+        
+        if (!this.Accessor.DirectoryExists("game")) return;
+            
+        string[] games = this.Accessor.GetDirectoriesInDirectory("game").ToArray();
+        
+        foreach (string gamePath in games)
+        {
+            string game = Path.GetFileName(gamePath);
+            
+            // Example TitleID: BCUS98208, must be 9 chars
+            if(game.Length != 9) continue; // Skip over profiles/save data/other garbage
+
+            GameItem item = new();
+            
+            string iconPath = Path.Combine(gamePath, "ICON0.PNG");
+            if (this.Accessor.FileExists(iconPath))
+            {
+                using Stream iconStream = this.Accessor.OpenRead(iconPath);
+                item.Image = new Bitmap(iconStream).WithSize(new Size(64, 64));
+            }
+
+            string sfoPath = Path.Combine(gamePath, "PARAM.SFO");
+            try
+            {
+                using Stream sfoStream = this.Accessor.OpenRead(sfoPath);
+                ParamSfo sfo = new(sfoStream);
+                item.Text = $"{sfo.Table["TITLE"]} [{game}]";
+            }
+            catch
+            {
+                item.Text = game;
+            }
+
+            item.TitleId = game;
+            
+            this._gameDropdown.Items.Add(item);
+        }
+    }
+
+    protected void GameChanged(object? sender, EventArgs ev)
+    {
+        GameItem? game = this._gameDropdown.SelectedValue as GameItem;
+        Debug.Assert(game != null);
+        Debug.Assert(this.Accessor != null);
+
+        this._usrDir = Path.Combine("game", game.TitleId, "USRDIR");
+        string ebootPath = this.Accessor.DownloadFile(Path.Combine(this._usrDir, "EBOOT.BIN"));
+        string rapDir = this.Accessor.DownloadDirectory(Path.Combine("home", "00000001", "exdata"));
+        
+        this.LogMessage($"EBOOT Path: {ebootPath}");
+        if (!this.Accessor.FileExists(ebootPath))
+        {
+            this.FailVerify("Could not find the EBOOT. Patching cannot continue.", clear: false);
+            return;
+        }
+
+        this._tempFile = Path.GetTempFileName();
+        
+        LibSceToolSharp.SetRapDirectory(rapDir);
+        LibSceToolSharp.Decrypt(ebootPath, this._tempFile);
+        
+        this.LogMessage($"The EBOOT has been successfully decrypted. It's stored at {this._tempFile}.");
+        
+        this.Patcher = new Patcher(File.Open(this._tempFile, FileMode.Open, FileAccess.ReadWrite));
+
+        this.Reverify(sender, ev);
+    }
+    
+    public override void CompletePatch(object? sender, EventArgs e) {
+        Debug.Assert(this.Accessor != null);
+        string identifier = string.IsNullOrWhiteSpace(this._outputField.Text) ? this._outputField.PlaceholderText : this._outputField.Text;
+        
+        string destination = Path.Combine(this._usrDir, $"EBOOT.{identifier}.elf");
+        
+        this.Accessor.UploadFile(this._tempFile, destination);
+        MessageBox.Show($"Successfully patched EBOOT! It was saved to '{destination}'.");
+
+        // Re-initialize patcher so we can patch with the same parameters again
+        // Probably slow but prevents crash
+        this.GameChanged(this, EventArgs.Empty);
+    }
+
+    protected abstract TableRow AddRemoteField();
+}

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -15,7 +15,8 @@ public class MainForm : RefresherForm
         (
             new Label { Text = "Welcome to Refresher! Please pick a patching method to continue." },
             new Button((_, _) => this.ShowChild<FilePatchForm>()) { Text = "File Patch (using a .ELF)" },
-            new Button((_, _) => this.ShowChild<EmulatorPatchForm>()) { Text = "RPCS3 Patch" }
+            new Button((_, _) => this.ShowChild<EmulatorPatchForm>()) { Text = "RPCS3 Patch" },
+            new Button((_, _) => this.ShowChild<ConsolePatchForm>()) { Text = "PS3 Patch" }
         );
 
         layout.Spacing = 5;


### PR DESCRIPTION
This is just a initial implementation. There are a couple bugs documented in the code I'd like to work out, but that can come later down the line.

## Notes:
- This doesn't support patching digital copies - we lack the method to grab the IDPS
- There's no option to disable fetching of game icons and param.sfos, which could cause a huge 30 second lag spike on wifi depending on the number of games installed (though it does already cause problems even on ethernet)
- There are issues with webMAN, mostly originating from the above problem. Too many requests can cause the ftpd to struggle.
- It seems to segfault right after patching, but patching still works
- This brings in a new library for FTP
- The FTP client will only connect if the server address textbox loses focus, which is terrible UX.

Closes #8