### PR TITLE
Add LBPK patching support

### DIFF
--- a/Refresher/Patching/PatchTargetInfo.cs
+++ b/Refresher/Patching/PatchTargetInfo.cs
@@ -2,11 +2,8 @@ namespace Refresher.Patching;
 
 public struct PatchTargetInfo
 {
-    
-    
     public long Offset;
     public int Length;
-    public string Data;
-
+    public string? Data;
     public PatchTargetType Type;
 }

--- a/Refresher/Patching/PatchTargetType.cs
+++ b/Refresher/Patching/PatchTargetType.cs
@@ -11,10 +11,6 @@ public enum PatchTargetType
     /// </summary>
     Host,
     /// <summary>
-    /// 2 32-bit big endian port numbers right after one another
-    /// </summary>
-    DoubleNumeric32BitPort,
-    /// <summary>
     /// A LBP digest key
     /// </summary>
     Digest,

--- a/Refresher/Patching/PatchTargetType.cs
+++ b/Refresher/Patching/PatchTargetType.cs
@@ -2,6 +2,20 @@ namespace Refresher.Patching;
 
 public enum PatchTargetType
 {
+    /// <summary>
+    /// A bog standard URL
+    /// </summary>
     Url,
+    /// <summary>
+    /// A domain only, no scheme, no port
+    /// </summary>
+    Host,
+    /// <summary>
+    /// 2 32-bit big endian port numbers right after one another
+    /// </summary>
+    DoubleNumeric32BitPort,
+    /// <summary>
+    /// A LBP digest key
+    /// </summary>
     Digest,
 }


### PR DESCRIPTION
Im not the happiest with this code, its heavily hardcoded for LBPK, but sadly we dont have any more advanced heuristics here, due to LBPK storing the server as separate host and port fields.

Note the port detection code may seem prone to false-positives, but, in reality, its not likely to ever get hit outside of LBPK, since `0x00, 0x00, 0x27, 0x42, 0x00, 0x00, 0x27, 0x43` is not valid assembly in any ISA, and the particular sequence of byte is unlikely to ever occur unless its the numbers `10050`, `10051`, but i would still like to put this code behind an "LBPK" blocker somehow, although im unsure of how to go about it (maybe only run this code if we find an LBPK url?) Marking as draft to be able to discuss this, reviews still wanted though.

Closes #34

Tested working with the latest digital copy of the game (1.20)