### PR TITLE
Handle errors a *little* more gracefully

### DIFF
--- a/Refresher/Accessors/ConsolePatchAccessor.cs
+++ b/Refresher/Accessors/ConsolePatchAccessor.cs
@@ -12,6 +12,7 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
     {
         this._client = new FtpClient(remoteIp, "anonymous", "");
         this._client.Config.LogToConsole = true;
+        this._client.Config.ConnectTimeout = 5000;
         this._client.AutoConnect();
     }
     

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -24,7 +24,34 @@ public class Program
         {
             Console.WriteLine("Launching in GUI mode");
             App = new Application();
-            App.Run(new MainForm());
+            App.UnhandledException += (sender, eventArgs)
+                => MessageBox.Show($"""
+                                    Unhandled error!
+                                    PLEASE
+                                    PLEASE
+                                    PLEASE
+                                    Send this message box to us with details! This is never intentional, you should never see this!
+                                    
+                                    {eventArgs.ExceptionObject}
+                                    """,
+                    "Critical Error!");
+            
+            try
+            {
+                App.Run(new MainForm());
+            }
+            catch(Exception ex)
+            {
+                MessageBox.Show($"""
+                                 Unhandled error!
+                                 PLEASE
+                                 PLEASE
+                                 PLEASE
+                                 Send this message box to us with details! This is never intentional, you should never see this!
+                                 
+                                 {ex}
+                                 """, "Critical Error!");
+            }
             App.Dispose();
         }
     }

--- a/Refresher/UI/ConsolePatchForm.cs
+++ b/Refresher/UI/ConsolePatchForm.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using Eto.Forms;
 using Refresher.Accessors;
 
@@ -12,36 +13,66 @@ public class ConsolePatchForm : IntegratedPatchForm
 
     protected override void PathChanged(object? sender, EventArgs ev)
     {
-        this.InitializePatchAccessor();
+        if (this._remoteAddress.Text.Trim().Length == 0)
+        {
+            MessageBox.Show("Please input a valid IP!", "Error");
+            return;
+        }
+
+        if (!this.InitializePatchAccessor()) 
+            return;
         base.PathChanged(sender, ev);
         this.DisposePatchAccessor();
     }
 
     protected override void GameChanged(object? sender, EventArgs ev)
     {
-        this.InitializePatchAccessor();
+        if (!this.InitializePatchAccessor()) 
+            return;
         base.GameChanged(sender, ev);
         this.DisposePatchAccessor();
     }
 
     public override void CompletePatch(object? sender, EventArgs e)
     {
-        this.InitializePatchAccessor();
+        if (!this.InitializePatchAccessor()) 
+            return;
         base.CompletePatch(sender, e);
         this.DisposePatchAccessor();
     }
 
     protected override void RevertToOriginalExecutable(object? sender, EventArgs e)
     {
-        this.InitializePatchAccessor();
+        if (!this.InitializePatchAccessor()) 
+            return;
         base.RevertToOriginalExecutable(sender, e);
         this.DisposePatchAccessor();
     }
 
-    private void InitializePatchAccessor()
+    private bool InitializePatchAccessor()
     {
         this.DisposePatchAccessor();
-        this.Accessor = new ConsolePatchAccessor(this._remoteAddress.Text);
+        try
+        {
+            this.Accessor = new ConsolePatchAccessor(this._remoteAddress.Text.Trim());
+        }
+        catch(TimeoutException)
+        {
+            MessageBox.Show($"Timed out waiting for response from PS3...\nAre you sure the webMAN FTP server is running?", "Error!");
+            return false;
+        }
+        catch(UriFormatException)
+        {
+            MessageBox.Show($"Unable to parse IP, make sure you typed it in correctly!", "Error!");
+            return false; 
+        }
+        catch(Exception ex)
+        {
+            MessageBox.Show($"Unknown error failed while connecting to PS3...\nAre you sure the IP is correct?\n\n{ex}", "Error!");
+            return false;
+        }
+
+        return true;
     }
 
     private void DisposePatchAccessor()


### PR DESCRIPTION
In PS3 patching we often would just crash for no reason, probably due to poor input validation of the IP in most cases, so now we catch more of that early before the exception bubbles up.

We also add an explicit timeout to FTP connections, before we would just lock up forever on my machine, which is a poor user experience.

This also adds a global exception handler, which throws up an error message to users telling them to report this.