### PR TITLE
Add custom user-agent for Refresher client

### DIFF
--- a/Refresher/UI/PatchForm.cs
+++ b/Refresher/UI/PatchForm.cs
@@ -155,6 +155,7 @@ public abstract class PatchForm<TPatcher> : RefresherForm where TPatcher : class
         {
             using HttpClient client = new();
             client.BaseAddress = autodiscoverUri;
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Refresher/3");
             
             HttpResponseMessage response = client.GetAsync("/autodiscover").Result;
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
This PR adds a custom user-agent for the Refresher app, closing #60.

The user-agent is built with `Refresher/<autodiscover-version>`. This was chosen over other options for a few reasons:

- This UA will be unique to Refresher, and servers can whitelist Refresher clients
   - Useful against repeated spam from bots and such
- Matching the autodiscover version can be useful *server-side*
   - Requests can be denied, for example, if something that is required is not available in an older version
      - v1 vs v2 is a great example of this! 
- The user-agent only needs to be updated when the AutoDiscover version changes

