### PR TITLE
Support releasing for macOS

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -77,7 +77,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "Refresher for Linux x64"
+          name: "refresher-linux-x64"
           path: "Refresher.tar"
           if-no-files-found: error
           retention-days: 30
@@ -86,7 +86,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "Refresher for Windows x64"
+          name: "refresher-win-x64"
           path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
           if-no-files-found: error
           retention-days: 30
@@ -95,7 +95,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "Refresher for macOS x64"
+          name: "refresher-macos-x64"
           path: "Refresher-x64.tar"
           if-no-files-found: error
           retention-days: 30
@@ -104,7 +104,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "Refresher for macOS ARM64"
+          name: "refresher-macos-arm64"
           path: "Refresher-arm64.tar"
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -77,7 +77,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "refresher-linux-x64"
+          name: "Refresher for Linux x64"
           path: "Refresher.tar"
           if-no-files-found: error
           retention-days: 30
@@ -86,7 +86,7 @@ jobs:
       if: matrix.os == 'windows-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "refresher-win-x64"
+          name: "Refresher for Windows x64"
           path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
           if-no-files-found: error
           retention-days: 30
@@ -95,7 +95,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "refresher-macos-x64"
+          name: "Refresher for macOS x64"
           path: "Refresher-x64.tar"
           if-no-files-found: error
           retention-days: 30
@@ -104,7 +104,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       uses: actions/upload-artifact@v3.1.1
       with:
-          name: "refresher-macos-arm64"
+          name: "Refresher for macOS ARM64"
           path: "Refresher-arm64.tar"
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     name: Build, Test, and Upload Builds (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,12 +39,49 @@ jobs:
         shell: bash
         run: dotnet publish -c Release -r win-x64 --self-contained Refresher //p:Version=${VERSION}
 
+      - name: Publish for macOS x64
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: dotnet publish -c Release -r osx-x64 --self-contained Refresher /p:Version=${VERSION}
+  
+      - name: Publish for macOS ARM64
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: dotnet publish -c Release -r osx-arm64 --self-contained Refresher /p:Version=${VERSION}
+      
+      - name: Remove duplicate .app for macOS x64
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        working-directory: Refresher/bin/Release/net8.0/osx-x64/publish/
+        run: rm -rfv ./*.app/Contents/MacOS/*.app && codesign -fs - --deep *.app
+  
+      - name: Remove duplicate .app for macOS ARM64
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        working-directory: Refresher/bin/Release/net8.0/osx-arm64/publish/
+        run: rm -rfv ./*.app/Contents/MacOS/*.app && codesign -fs - --deep *.app
+        
+      # We need to tarball our macOS and Linux builds, since the ZIP files created by upload-artifact do not retain extended unix file permissions, 
+      # which means the executable bit is lost, which is un-ideal for end users, who will hit weird errors (especially relating to code signing on macOS)
+      - name: 'Tar macOS x64 build'
+        if: matrix.os == 'macos-latest'
+        working-directory: Refresher/bin/Release/net8.0/osx-x64/publish/
+        run: tar -cvf ../../../../../../Refresher-x64.tar *.app
+      - name: 'Tar macOS ARM64 build'
+        if: matrix.os == 'macos-latest'
+        working-directory: Refresher/bin/Release/net8.0/osx-arm64/publish/
+        run: tar -cvf ../../../../../../Refresher-arm64.tar *.app 
+      - name: 'Tar Linux x64'
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: Refresher/bin/Release/net8.0/linux-x64/publish/
+        run: tar -cvf ../../../../../../Refresher.tar * 
+
       - name: Upload Linux x64 build
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3.1.3
         with:
-            name: "Refresher_for_Linux_x64"
-            path: "Refresher/bin/Release/net8.0/linux-x64/publish/"
+            name: "refresher-linux-x64"
+            path: "Refresher.tar"
             if-no-files-found: error
             retention-days: 1
 
@@ -52,8 +89,26 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3.1.3
         with:
-            name: "Refresher_for_Windows_x64"
+            name: "refresher-win-x64"
             path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
+            if-no-files-found: error
+            retention-days: 1
+
+      - name: Upload macOS x64 build
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v3.1.1
+        with:
+            name: "refresher-macos-x64"
+            path: "Refresher-x64.tar"
+            if-no-files-found: error
+            retention-days: 30
+  
+      - name: Upload macOS ARM64 build
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v3.1.1
+        with:
+            name: "refresher-macos-arm64"
+            path: "Refresher-arm64.tar"
             if-no-files-found: error
             retention-days: 1
   release:
@@ -61,23 +116,34 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        id: src
+
       - name: Download artifacts
         id: download
         uses: actions/download-artifact@v3.0.2
 
       - name: Create zip files
         run: |
-            cd ${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64
-            zip -r "${{steps.download.outputs.download-path}}/Refresh_for_Windows_x64.zip" .
+            cd ${{steps.download.outputs.download-path}}/refresher-win-x64
+            zip -r "${{steps.download.outputs.download-path}}/refresher-win-x64.zip" .
             
-            cd ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64
-            zip -r "${{steps.download.outputs.download-path}}/Refresh_for_Linux_x64.zip" .
+            cd ${{steps.download.outputs.download-path}}/refresher-linux-x64
+            zip -r "${{steps.download.outputs.download-path}}/refresher-linux-x64.zip" .
+
+            cd ${{steps.download.outputs.download-path}}/refresher-macos-x64
+            zip -r "${{steps.download.outputs.download-path}}/refresher-macos-x64.zip" .
+
+            cd ${{steps.download.outputs.download-path}}/refresher-macos-arm64
+            zip -r "${{steps.download.outputs.download-path}}/refresher-macos-arm64.zip" .
         
-      - uses: marvinpinto/action-automatic-releases@latest
+      - uses: ncipollo/release-action@v1.14.0
         name: "Create release"
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false
           draft: true
-          files: |
+          generateReleaseNotes: true
+          bodyFile: "RELEASE_NOTES.md"
+          artifacts: |
             *.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v3.1.3
         with:
-            name: "refresher-linux-x64"
+            name: "Refresher_for_Linux_x64"
             path: "Refresher.tar"
             if-no-files-found: error
             retention-days: 1
@@ -89,7 +89,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v3.1.3
         with:
-            name: "refresher-win-x64"
+            name: "Refresher_for_Windows_x64"
             path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
             if-no-files-found: error
             retention-days: 1
@@ -98,7 +98,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v3.1.1
         with:
-            name: "refresher-macos-x64"
+            name: "Refresher_for_macOS_x64"
             path: "Refresher-x64.tar"
             if-no-files-found: error
             retention-days: 30
@@ -107,7 +107,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v3.1.1
         with:
-            name: "refresher-macos-arm64"
+            name: "Refresher_for_macOS_ARM64"
             path: "Refresher-arm64.tar"
             if-no-files-found: error
             retention-days: 1
@@ -125,17 +125,17 @@ jobs:
 
       - name: Create zip files
         run: |
-            cd ${{steps.download.outputs.download-path}}/refresher-win-x64
-            zip -r "${{steps.download.outputs.download-path}}/refresher-win-x64.zip" .
+            cd ${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64
+            zip -r "${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64.zip" .
             
-            cd ${{steps.download.outputs.download-path}}/refresher-linux-x64
-            zip -r "${{steps.download.outputs.download-path}}/refresher-linux-x64.zip" .
+            cd ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64
+            zip -r "${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64.zip" .
 
-            cd ${{steps.download.outputs.download-path}}/refresher-macos-x64
-            zip -r "${{steps.download.outputs.download-path}}/refresher-macos-x64.zip" .
+            cd ${{steps.download.outputs.download-path}}/Refresher_for_macOS_x64
+            zip -r "${{steps.download.outputs.download-path}}/Refresher_for_macOS_x64.zip" .
 
-            cd ${{steps.download.outputs.download-path}}/refresher-macos-arm64
-            zip -r "${{steps.download.outputs.download-path}}/refresher-macos-arm64.zip" .
+            cd ${{steps.download.outputs.download-path}}/Refresher_for_macOS_ARM64
+            zip -r "${{steps.download.outputs.download-path}}/Refresher_for_macOS_ARM64.zip" .
         
       - uses: ncipollo/release-action@v1.14.0
         name: "Create release"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
             name: "Refresher_for_macOS_x64"
             path: "Refresher-x64.tar"
             if-no-files-found: error
-            retention-days: 30
+            retention-days: 1
   
       - name: Upload macOS ARM64 build
         if: matrix.os == 'macos-latest'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+**NOTE:** Due to restrictions imposed on ad-hoc signed apps, macOS users may need to run the following command in Terminal before launching the app. Replace `/path/to` with the folder containing `Refresher.app`.
+
+```
+xattr -d com.apple.quarantine /path/to/Refresher.app
+```


### PR DESCRIPTION
This PR enables `release.yml` to build for macOS, and renames the output files to be a little nicer to read: 
`refresher-<platform>-<arch>`
- This is partly in preparation for work on Linux + Windows ARM64.
- After this PR, macOS support should be good to go!

An example of the output:
<img width="1174" alt="Screenshot 2" src="https://github.com/LittleBigRefresh/Refresher/assets/55281754/0ae0467a-ca1e-4cdd-9eea-1184c5860ab6">

Please note the changelog difference - this is because of the way GitHub's autogenerated release notes work. 