### PR TITLE
Fix available length not counting the first null byte

### DIFF
--- a/Refresher/Patching/EbootPatcher.cs
+++ b/Refresher/Patching/EbootPatcher.cs
@@ -220,7 +220,10 @@ public partial class EbootPatcher : IPatcher
             }
 
             if (tooLong) continue;
-
+            
+            //Seek back to first null byte
+            reader.BaseStream.Position = foundPosition + len;
+            
             //Keep reading until we arent at a null byte
             while (reader.ReadByte() == 0) len++;
 


### PR DESCRIPTION
This PR makes so that the reader's position is set back to the first null byte before it starts counting the amount of null bytes. This resolves an issue where the believed available space would always be one less than what was actually available (two if counting the intentional spacing).

