### PR TITLE
Move non-UI components to new `Refresher.Core` project, move to NotEnoughLogs

### DIFF
--- a/Refresher.Core/Accessors/ConsolePatchAccessor.cs
+++ b/Refresher.Core/Accessors/ConsolePatchAccessor.cs
@@ -1,7 +1,7 @@
 using FluentFTP;
-using Refresher.Exceptions;
+using Refresher.Core.Exceptions;
 
-namespace Refresher.Accessors;
+namespace Refresher.Core.Accessors;
 
 public class ConsolePatchAccessor : PatchAccessor, IDisposable
 {
@@ -27,7 +27,7 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
     
     private byte[]? GetIdps()
     {
-        Program.Log("Getting IDPS...", "IDPS");
+        State.Logger.LogInfo(IDPS, "Getting IDPS from the console...");
         UriBuilder idpsPs3 = new("http", this._remoteIp, 80, "idps.ps3");
         UriBuilder idpsHex = new("http", this._remoteIp, 80, "dev_hdd0/idps.hex");
         UriBuilder idpsHexUsb = new("http", this._remoteIp, 80, "dev_usb000/idps.hex");
@@ -48,7 +48,7 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
     {
         HttpResponseMessage response;
         
-        Program.Log($"  {stepName} ({uri.AbsolutePath})", "IDPS");
+        State.Logger.LogDebug(IDPS, $"  {stepName} ({uri.AbsolutePath})");
         try
         {
             response = client.GetAsync(uri).Result;
@@ -62,17 +62,17 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
         {
             if (!HandleIdpsRequestError(e))
             {
-                Program.Log($"Couldn't fetch the IDPS from the PS3 because of an unknown error: {e}", "IDPS", BreadcrumbLevel.Error);
+                State.Logger.LogError(IDPS, $"Couldn't fetch the IDPS from the PS3 because of an unknown error: {e}");
                 SentrySdk.CaptureException(e);
             }
             return null;
         }
-        Program.Log($"    {(int)response.StatusCode} {response.StatusCode} (success: {response.IsSuccessStatusCode})", "IDPS");
+        State.Logger.LogDebug(IDPS, $"    {(int)response.StatusCode} {response.StatusCode} (success: {response.IsSuccessStatusCode})");
         
         if (!response.IsSuccessStatusCode)
         {
-            Program.Log("Couldn't fetch the IDPS from the PS3 because of a bad status code.", "IDPS", BreadcrumbLevel.Error);
-            Program.Log(response.Content.ReadAsStringAsync().Result, "IDPS", BreadcrumbLevel.Debug);
+            State.Logger.LogError(IDPS, "Couldn't fetch the IDPS from the PS3 because of a bad status code.");
+            State.Logger.LogDebug(IDPS, response.Content.ReadAsStringAsync().Result);
             return null;
         }
         
@@ -83,7 +83,7 @@ public class ConsolePatchAccessor : PatchAccessor, IDisposable
     {
         if (inner is HttpRequestException httpException)
         {
-            Program.Log($"Couldn't fetch the IDPS from the PS3 because we couldn't make the request: {httpException.Message}", "IDPS", BreadcrumbLevel.Error);
+            State.Logger.LogError(IDPS, $"Couldn't fetch the IDPS from the PS3 because we couldn't make the request: {httpException.Message}");
             return true;
         }
 

--- a/Refresher.Core/Accessors/EmulatorPatchAccessor.cs
+++ b/Refresher.Core/Accessors/EmulatorPatchAccessor.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Accessors;
+namespace Refresher.Core.Accessors;
 
 public class EmulatorPatchAccessor : PatchAccessor
 {

--- a/Refresher.Core/Accessors/GameCacheAccessor.cs
+++ b/Refresher.Core/Accessors/GameCacheAccessor.cs
@@ -1,6 +1,4 @@
-using Eto.Forms;
-
-namespace Refresher.Accessors;
+namespace Refresher.Core.Accessors;
 
 public static class GameCacheAccessor
 {
@@ -19,8 +17,9 @@ public static class GameCacheAccessor
         }
         catch (IOException e)
         {
-            MessageBox.Show($"Couldn't create the directory for the games cache: {e.Message}\n" +
-                            $"This error is rare and I don't know how to cleanly handle this scenario so Refresher is just gonna exit.");
+            // FIXME: no native MessageBox in Refresher.Core
+            // MessageBox.Show($"Couldn't create the directory for the games cache: {e.Message}\n" +
+            //                 $"This error is rare and I don't know how to cleanly handle this scenario so Refresher is just gonna exit.");
             Environment.Exit(1); // shrug
         }
     }

--- a/Refresher.Core/Accessors/PatchAccessor.cs
+++ b/Refresher.Core/Accessors/PatchAccessor.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Accessors;
+namespace Refresher.Core.Accessors;
 
 public abstract class PatchAccessor
 {

--- a/Refresher.Core/Exceptions/FTPConnectionFailureException.cs
+++ b/Refresher.Core/Exceptions/FTPConnectionFailureException.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
-namespace Refresher.Exceptions;
+namespace Refresher.Core.Exceptions;
 
 public class FTPConnectionFailureException() : Exception("Could not connect to the FTP server.");

--- a/Refresher.Core/GlobalUsings.cs
+++ b/Refresher.Core/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static Refresher.Core.LogType;

--- a/Refresher.Core/LogType.cs
+++ b/Refresher.Core/LogType.cs
@@ -1,0 +1,18 @@
+namespace Refresher.Core;
+
+public enum LogType : byte
+{
+    Patcher,
+    PPU,
+    Verify,
+    CLI,
+    PatchAccessor,
+    PatchForm,
+    IntegratedPatchForm,
+    InfoRetrieval,
+    Crypto,
+    IDPS,
+    OSIntegration,
+    AutoDiscover,
+    PSP,
+}

--- a/Refresher.Core/Logging/SentryBreadcrumbSink.cs
+++ b/Refresher.Core/Logging/SentryBreadcrumbSink.cs
@@ -1,0 +1,31 @@
+using NotEnoughLogs;
+using NotEnoughLogs.Sinks;
+
+namespace Refresher.Core.Logging;
+
+public class SentryBreadcrumbSink : ILoggerSink
+{
+    private static BreadcrumbLevel GetLevel(LogLevel level)
+    {
+        return level switch
+        {
+            LogLevel.Critical => BreadcrumbLevel.Critical,
+            LogLevel.Error => BreadcrumbLevel.Error,
+            LogLevel.Warning => BreadcrumbLevel.Warning,
+            LogLevel.Info => BreadcrumbLevel.Info,
+            LogLevel.Debug => BreadcrumbLevel.Debug,
+            LogLevel.Trace => BreadcrumbLevel.Debug,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
+        };
+    }
+    
+    public void Log(LogLevel level, ReadOnlySpan<char> category, ReadOnlySpan<char> content)
+    {
+        SentrySdk.AddBreadcrumb(content.ToString(), category.ToString(), level: GetLevel(level));
+    }
+
+    public void Log(LogLevel level, ReadOnlySpan<char> category, ReadOnlySpan<char> format, params object[] args)
+    {
+        SentrySdk.AddBreadcrumb(string.Format(format.ToString(), args), category.ToString(), level: GetLevel(level));
+    }
+}

--- a/Refresher.Core/Patching/EbootPatcher.cs
+++ b/Refresher.Core/Patching/EbootPatcher.cs
@@ -7,9 +7,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using ELFSharp.ELF;
 using ELFSharp.ELF.Segments;
-using Refresher.Verification;
+using Refresher.Core.Verification;
 
-namespace Refresher.Patching;
+namespace Refresher.Core.Patching;
 
 public partial class EbootPatcher : IPatcher
 {
@@ -141,7 +141,7 @@ public partial class EbootPatcher : IPatcher
         FindLbpkDomains(reader, lbpkPositions, foundItems);
 
         long end = Stopwatch.GetTimestamp();
-        Program.Log($"Detecting patchables took {(double)(end - start) / (double)Stopwatch.Frequency} seconds!");
+        State.Logger.LogDebug(Patcher, $"Detecting patchables took {(end - start) / (double)Stopwatch.Frequency} seconds!");
         return foundItems;
     }
     
@@ -245,7 +245,7 @@ public partial class EbootPatcher : IPatcher
 
             if (UrlMatch().Matches(str).Count != 0)
             {
-                Program.Log($"Found URL at offset {foundPosition}: '{str}'");
+                State.Logger.LogTrace(Patcher, $"Found URL at offset {foundPosition}: '{str}'");
                 foundItems.Add(new PatchTargetInfo
                 {
                     Length = len,
@@ -344,7 +344,7 @@ public partial class EbootPatcher : IPatcher
         
         string ppuHash = BitConverter.ToString(hash.Hash!).Replace("-", "").ToLower();
         
-        Program.Log($"PPU hash: PPU-{ppuHash}", "PPU", BreadcrumbLevel.Debug);
+        State.Logger.LogDebug(PPU, $"PPU hash: PPU-{ppuHash}");
         return ppuHash;
     }
 
@@ -359,7 +359,7 @@ public partial class EbootPatcher : IPatcher
 
         this.Stream.Position = 0;
 
-        Program.Log($"URL: {url}", "Verify");
+        State.Logger.LogInfo(LogType.Verify, $"Verifying EBOOT against URL: {url}");
         // Check url
         if (url.EndsWith('/'))
             messages.Add(new Message(MessageLevel.Error,
@@ -373,7 +373,7 @@ public partial class EbootPatcher : IPatcher
         {
             Class output = ELFReader.CheckELFType(this.Stream);
 
-            Program.Log($"ELF class: {output}", "Verify");
+            State.Logger.LogDebug(LogType.Verify, $"ELF class: {output}");
             if (output == Class.NotELF)
             {
                 messages.Add(new Message(MessageLevel.Error, "EBOOT is not a valid ELF file."));

--- a/Refresher.Core/Patching/IPatcher.cs
+++ b/Refresher.Core/Patching/IPatcher.cs
@@ -1,6 +1,6 @@
-using Refresher.Verification;
+using Refresher.Core.Verification;
 
-namespace Refresher.Patching;
+namespace Refresher.Core.Patching;
 
 public interface IPatcher
 {

--- a/Refresher.Core/Patching/PSP/PSPPluginListEntry.cs
+++ b/Refresher.Core/Patching/PSP/PSPPluginListEntry.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Patching.PSP;
+namespace Refresher.Core.Patching.PSP;
 
 public class PSPPluginListEntry
 {

--- a/Refresher.Core/Patching/PSP/PSPPluginListParser.cs
+++ b/Refresher.Core/Patching/PSP/PSPPluginListParser.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Patching.PSP;
+namespace Refresher.Core.Patching.PSP;
 
 public static class PSPPluginListParser
 {

--- a/Refresher.Core/Patching/PSPPatcher.cs
+++ b/Refresher.Core/Patching/PSPPatcher.cs
@@ -1,8 +1,8 @@
 using System.Reflection;
-using Refresher.Patching.PSP;
-using Refresher.Verification;
+using Refresher.Core.Patching.PSP;
+using Refresher.Core.Verification;
 
-namespace Refresher.Patching;
+namespace Refresher.Core.Patching;
 
 public class PSPPatcher : IPatcher
 {

--- a/Refresher.Core/Patching/PatchTargetInfo.cs
+++ b/Refresher.Core/Patching/PatchTargetInfo.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Patching;
+namespace Refresher.Core.Patching;
 
 public struct PatchTargetInfo
 {

--- a/Refresher.Core/Patching/PatchTargetType.cs
+++ b/Refresher.Core/Patching/PatchTargetType.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Patching;
+namespace Refresher.Core.Patching;
 
 public enum PatchTargetType
 {

--- a/Refresher.Core/Refresher.Core.csproj
+++ b/Refresher.Core/Refresher.Core.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="FluentFTP" Version="49.0.2" />
+        <PackageReference Include="NotEnoughLogs" Version="2.0.3" />
+        <PackageReference Include="SCEToolSharp" Version="1.2.2" />
+        <PackageReference Include="ELFSharp" Version="2.17.3" />
+        <PackageReference Include="Sentry" Version="4.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/Refresher.Core/State.cs
+++ b/Refresher.Core/State.cs
@@ -1,0 +1,23 @@
+using NotEnoughLogs;
+using NotEnoughLogs.Behaviour;
+using NotEnoughLogs.Sinks;
+using Refresher.Core.Logging;
+
+namespace Refresher.Core;
+
+public static class State
+{
+    public static readonly Logger Logger = InitializeLogger([new ConsoleSink(), new SentryBreadcrumbSink()]);
+
+    private static Logger InitializeLogger(IEnumerable<ILoggerSink> sinks)
+    {
+        // if(Logger != null)
+            // Logger.Dispose();
+
+        return new Logger(sinks, new LoggerConfiguration
+        {
+            Behaviour = new DirectLoggingBehaviour(),
+            MaxLevel = LogLevel.Trace,
+        });
+    }
+}

--- a/Refresher.Core/Verification/Autodiscover/AutodiscoverResponse.cs
+++ b/Refresher.Core/Verification/Autodiscover/AutodiscoverResponse.cs
@@ -1,6 +1,6 @@
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
-namespace Refresher.Verification.Autodiscover;
+namespace Refresher.Core.Verification.Autodiscover;
 
 #nullable disable
 
@@ -8,15 +8,15 @@ public class AutodiscoverResponse
 {
     private const int SupportedVersion = 2;
 
-    [JsonProperty("version")]
+    [JsonPropertyName("version")]
     public int Version { get; set; }
 
-    [JsonProperty("serverBrand")]
+    [JsonPropertyName("serverBrand")]
     public string ServerBrand { get; set; }
         
-    [JsonProperty("url")]
+    [JsonPropertyName("url")]
     public string Url { get; set; }
 
-    [JsonProperty("usesCustomDigestKey")]
+    [JsonPropertyName("usesCustomDigestKey")]
     public bool? UsesCustomDigestKey { get; set; } = false; // We mark as nullable, as this was added in version 2
 }

--- a/Refresher.Core/Verification/Message.cs
+++ b/Refresher.Core/Verification/Message.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Verification;
+namespace Refresher.Core.Verification;
 
 public readonly struct Message
 {

--- a/Refresher.Core/Verification/MessageLevel.cs
+++ b/Refresher.Core/Verification/MessageLevel.cs
@@ -1,4 +1,4 @@
-namespace Refresher.Verification;
+namespace Refresher.Core.Verification;
 
 public enum MessageLevel
 {

--- a/Refresher.Core/Verification/ParamSfo.cs
+++ b/Refresher.Core/Verification/ParamSfo.cs
@@ -1,6 +1,6 @@
 using System.Text;
 
-namespace Refresher.Verification;
+namespace Refresher.Core.Verification;
 
 // TODO: Move to separate repository with its own nuget package
 // Maybe combine with NPTicket?

--- a/Refresher.sln
+++ b/Refresher.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresher", "Refresher\Refresher.csproj", "{0A67E8A2-0E7C-4BB7-90E5-8D8EA59631D4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresher.Core", "Refresher.Core\Refresher.Core.csproj", "{49CE141A-8BD7-4CD5-BE86-257BDA5C5796}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{0A67E8A2-0E7C-4BB7-90E5-8D8EA59631D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A67E8A2-0E7C-4BB7-90E5-8D8EA59631D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A67E8A2-0E7C-4BB7-90E5-8D8EA59631D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49CE141A-8BD7-4CD5-BE86-257BDA5C5796}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49CE141A-8BD7-4CD5-BE86-257BDA5C5796}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49CE141A-8BD7-4CD5-BE86-257BDA5C5796}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49CE141A-8BD7-4CD5-BE86-257BDA5C5796}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Refresher/GlobalUsings.cs
+++ b/Refresher/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using static Refresher.Core.LogType;

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using CommandLine;
 using Eto.Forms;
 using Refresher.CLI;
+using Refresher.Core;
 using Refresher.UI;
 
 namespace Refresher;
@@ -57,7 +58,7 @@ public class Program
         
         if (args.Length > 0)
         {
-            Log("Launching in CLI mode");
+            State.Logger.LogInfo(OSIntegration, "Launching in CLI mode");
             
             AppDomain.CurrentDomain.UnhandledException += (_, eventArgs) =>
             {
@@ -70,7 +71,7 @@ public class Program
         }
         else
         {
-            Log("Launching in GUI mode");
+            State.Logger.LogInfo(OSIntegration, "Launching in GUI mode");
             try
             {
                 App = new Application();

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -42,18 +42,18 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
-      <PackageReference Include="ELFSharp" Version="2.17.3" />
       <PackageReference Include="Eto.Forms" Version="2.8.3" />
       <!-- This could be IsLinux, but GTK is available on basically everything, so might as well use it as the true default -->
       <PackageReference Condition="!$(IsWindows) And !$(IsOSX)" Include="Eto.Platform.Gtk" Version="2.8.3" />
       <PackageReference Condition="$(IsOSX)" Include="Eto.Platform.Mac64" Version="2.8.3" />
       <PackageReference Condition="$(IsWindows)" Include="Eto.Platform.Wpf" Version="2.8.3" />
       <EmbeddedResource Include="Resources\refresher.ico" LogicalName="refresher.ico" />
-      <PackageReference Include="FluentFTP" Version="49.0.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="SCEToolSharp" Version="1.2.2" />
       <EmbeddedResource Include="Resources\Allefresher.prx" />
       <PackageReference Include="Sentry" Version="4.4.0" />
       <Content Include="Resources/refresher.icns" Link="refresher.icns" Condition="$(IsOSX)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Refresher.Core\Refresher.Core.csproj" />
     </ItemGroup>
 </Project>

--- a/Refresher/UI/ConsolePatchForm.cs
+++ b/Refresher/UI/ConsolePatchForm.cs
@@ -1,8 +1,9 @@
 using System.Net.Sockets;
 using System.Reflection;
 using Eto.Forms;
-using Refresher.Accessors;
-using Refresher.Exceptions;
+using Refresher.Core;
+using Refresher.Core.Accessors;
+using Refresher.Core.Exceptions;
 
 namespace Refresher.UI;
 
@@ -54,7 +55,7 @@ public class ConsolePatchForm : IntegratedPatchForm
     private bool InitializePatchAccessor()
     {
         this.DisposePatchAccessor();
-        Program.Log("Making a new patch accessor", "Accessor");
+        State.Logger.LogTrace(LogType.PatchAccessor, "Making a new patch accessor");
         try
         {
             this.Accessor = new ConsolePatchAccessor(this._remoteAddress.Text.Trim());
@@ -85,14 +86,14 @@ public class ConsolePatchForm : IntegratedPatchForm
 
     private void DisposePatchAccessor()
     {
-        Program.Log("Disposing patch accessor", "Accessor");
+        State.Logger.LogTrace(LogType.PatchAccessor, "Disposing patch accessor");
         if (this.Accessor is IDisposable disposable)
             disposable.Dispose();
     }
 
     protected override IEnumerable<TableRow> AddFields()
     {
-        return new[] { AddField("PS3's IP", out this._remoteAddress, new Button(this.PathChanged) { Text = "Connect" }) };
+        return [AddField("PS3's IP", out this._remoteAddress, new Button(this.PathChanged) { Text = "Connect" })];
     }
     
     public override void Guide(object? sender, EventArgs e)

--- a/Refresher/UI/EmulatorFilePatchForm.cs
+++ b/Refresher/UI/EmulatorFilePatchForm.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using Eto;
 using Eto.Forms;
-using Refresher.Accessors;
+using Refresher.Core.Accessors;
 using Refresher.UI.Items;
 
 namespace Refresher.UI;

--- a/Refresher/UI/EmulatorPatchForm.cs
+++ b/Refresher/UI/EmulatorPatchForm.cs
@@ -1,7 +1,8 @@
 using System.Diagnostics;
 using Eto;
 using Eto.Forms;
-using Refresher.Accessors;
+using Refresher.Core;
+using Refresher.Core.Accessors;
 using Refresher.UI.Items;
 
 namespace Refresher.UI;
@@ -38,7 +39,7 @@ public class EmulatorPatchForm : IntegratedPatchForm
     {
         if (this.GameDropdown.SelectedValue is not GameItem game)
         {
-            Program.Log("Game was null before patch, bailing", nameof(EmulatorPatchForm));
+            State.Logger.LogError(PatchForm, "Game was null before patch, bailing");
             return;
         }
         
@@ -57,7 +58,7 @@ public class EmulatorPatchForm : IntegratedPatchForm
             }
             catch (Exception ex)
             {
-                Program.Log($"Exception while trying to create RPCS3 patches folder: {ex}", nameof(ConsolePatchAccessor), BreadcrumbLevel.Warning);
+                State.Logger.LogError(PatchForm, $"Exception while trying to create RPCS3 patches folder: {ex}");
             }
         }
     }
@@ -93,7 +94,7 @@ public class EmulatorPatchForm : IntegratedPatchForm
         
         if (this.Patcher == null)
         {
-            Program.Log("Patcher was null, bailing", nameof(EmulatorPatchForm));
+            State.Logger.LogError(PatchForm, "Patcher was null, bailing");
             return;
         }
         

--- a/Refresher/UI/FilePatchForm.cs
+++ b/Refresher/UI/FilePatchForm.cs
@@ -1,7 +1,8 @@
 using System.IO.MemoryMappedFiles;
 using Eto;
 using Eto.Forms;
-using Refresher.Patching;
+using Refresher.Core.Patching;
+using Refresher.Core.Patching;
 
 namespace Refresher.UI;
 

--- a/Refresher/UI/PSPSetupForm.cs
+++ b/Refresher/UI/PSPSetupForm.cs
@@ -1,5 +1,7 @@
 using Eto.Forms;
-using Refresher.Patching;
+using Refresher.Core;
+using Refresher.Core.Patching;
+using Refresher.Core.Patching;
 
 namespace Refresher.UI;
 
@@ -31,7 +33,7 @@ public class PSPSetupForm : PatchForm<PSPPatcher>
 
             try
             {
-                Program.Log($"Checking drive {drive.Name}...");
+                State.Logger.LogInfo(PSP, $"Checking drive {drive.Name}...");
 
                 // Match for all directories called PSP and PSPEMU
                 // NOTE: we do this because the PSP filesystem is case insensitive, and the .NET STL is case sensitive on linux
@@ -50,7 +52,7 @@ public class PSPSetupForm : PatchForm<PSPPatcher>
                 // If theres no PSP folder or PSPEMU folder,
                 if (!possiblePspMatches.Any() && !possiblePsVitaMatches.Any())
                 {
-                    Program.Log($"Drive {drive.Name} has no PSP/PSPEMU folder, ignoring...");
+                    State.Logger.LogInfo(PSP, $"Drive {drive.Name} has no PSP/PSPEMU folder, ignoring...");
                     
                     //Skip this drive
                     continue;
@@ -61,10 +63,8 @@ public class PSPSetupForm : PatchForm<PSPPatcher>
             }
             catch(Exception ex)
             {
-                Program.Log("Checking drive failed due to exception, see below");
-                Program.Log(ex.ToString());
-                
-                //If we fail to check dir info, its probably not mounted in a safe/accessible way
+                State.Logger.LogError(PSP, $"Couldn't check the drive due to an exception: {ex}");
+                // If we fail to check dir info, it's probably not mounted in a safe/accessible way
                 continue;
             }
             

--- a/Refresher/UI/RefresherForm.cs
+++ b/Refresher/UI/RefresherForm.cs
@@ -2,6 +2,7 @@ using Eto.Drawing;
 using Eto.Forms;
 using Sentry;
 using System.Runtime.InteropServices;
+using Refresher.Core;
 
 namespace Refresher.UI;
 
@@ -38,7 +39,7 @@ public abstract class RefresherForm : Form
         TForm form = new();
         form.Show();
         
-        Program.Log($"Showing child form {form.GetType().Name} '{form.Title}'");
+        State.Logger.LogDebug(OSIntegration, $"Showing child form {form.GetType().Name} '{form.Title}'");
 
         if (close) this.Visible = false;
     }


### PR DESCRIPTION
This is the first of many changes to bring Refresher up to a better code quality standard. I want to move all of our logic away from the UI, and this is a first good step in that direction. The plan is to have `Refresher.Core` behave independently from a front-end, and thus make it re-usable and more consistent.

Ideally this allows us to make a better CLI experience and allow us to introduce more front-ends (e.g. an Android app through Xamarin?).