### PR TITLE
Framework for "pipelines"

### DIFF
--- a/Refresher.Core/LogType.cs
+++ b/Refresher.Core/LogType.cs
@@ -15,4 +15,5 @@ public enum LogType : byte
     OSIntegration,
     AutoDiscover,
     PSP,
+    Pipeline
 }

--- a/Refresher.Core/Logging/EventSink.cs
+++ b/Refresher.Core/Logging/EventSink.cs
@@ -1,0 +1,17 @@
+using NotEnoughLogs;
+using NotEnoughLogs.Sinks;
+
+namespace Refresher.Core.Logging;
+
+public class EventSink : ILoggerSink
+{
+    public void Log(LogLevel level, ReadOnlySpan<char> category, ReadOnlySpan<char> content)
+    {
+        State.InvokeOnLog(level, category, content);
+    }
+
+    public void Log(LogLevel level, ReadOnlySpan<char> category, ReadOnlySpan<char> format, params object[] args)
+    {
+        this.Log(level, category, string.Format(format.ToString(), args));
+    }
+}

--- a/Refresher.Core/Logging/RefresherLog.cs
+++ b/Refresher.Core/Logging/RefresherLog.cs
@@ -1,0 +1,19 @@
+using NotEnoughLogs;
+
+namespace Refresher.Core.Logging;
+
+#nullable disable
+
+public readonly struct RefresherLog
+{
+    public RefresherLog(LogLevel level, string category, string content)
+    {
+        this.Level = level;
+        this.Category = category;
+        this.Content = content;
+    }
+
+    public readonly LogLevel Level;
+    public readonly string Category;
+    public readonly string Content;
+}

--- a/Refresher.Core/Pipelines/ExamplePipeline.cs
+++ b/Refresher.Core/Pipelines/ExamplePipeline.cs
@@ -9,10 +9,10 @@ public class ExamplePipeline : Pipeline
     protected override List<Type> StepTypes { get; } =
     [
         typeof(ExampleInputStep),
-        typeof(ExampleStep),
-        typeof(ExampleStep),
-        typeof(ExampleStep),
-        typeof(ExampleStep),
-        typeof(ExampleStep),
+        typeof(DelayOneSecondStep),
+        typeof(DelayOneSecondStep),
+        typeof(DelayOneSecondStep),
+        typeof(DelayOneSecondStep),
+        typeof(DelayOneSecondStep),
     ];
 }

--- a/Refresher.Core/Pipelines/ExamplePipeline.cs
+++ b/Refresher.Core/Pipelines/ExamplePipeline.cs
@@ -8,6 +8,7 @@ public class ExamplePipeline : Pipeline
     public override string Name => "Example Pipeline";
     protected override List<Type> StepTypes { get; } =
     [
+        typeof(ExampleInputStep),
         typeof(ExampleStep),
         typeof(ExampleStep),
         typeof(ExampleStep),

--- a/Refresher.Core/Pipelines/ExamplePipeline.cs
+++ b/Refresher.Core/Pipelines/ExamplePipeline.cs
@@ -1,0 +1,17 @@
+using Refresher.Core.Pipelines.Steps;
+
+namespace Refresher.Core.Pipelines;
+
+public class ExamplePipeline : Pipeline
+{
+    public override string Id => "example";
+    public override string Name => "Example Pipeline";
+    protected override List<Type> StepTypes { get; } =
+    [
+        typeof(ExampleStep),
+        typeof(ExampleStep),
+        typeof(ExampleStep),
+        typeof(ExampleStep),
+        typeof(ExampleStep),
+    ];
+}

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -1,6 +1,5 @@
+using System.Collections.Frozen;
 using System.Diagnostics;
-using System.Reflection;
-using NotEnoughLogs;
 
 using GlobalState = Refresher.Core.State;
 
@@ -10,6 +9,9 @@ public abstract class Pipeline
 {
     public abstract string Id { get; }
     public abstract string Name { get; }
+    
+    public Dictionary<string, string> Inputs = [];
+    public FrozenSet<StepInput> RequiredInputs { get; private set; }
     
     public PipelineState State { get; private set; } = PipelineState.NotStarted;
     
@@ -33,13 +35,20 @@ public abstract class Pipeline
 
     public void Initialize()
     {
+        List<StepInput> requiredInputs = [];
+        
         this._steps = new List<Step>(this.StepTypes.Count);
         foreach (Type type in this.StepTypes)
         {
             Debug.Assert(type.IsAssignableTo(typeof(Step)));
+
             Step step = (Step)Activator.CreateInstance(type, this)!;
+
             this._steps.Add(step);
+            requiredInputs.AddRange(step.Inputs);
         }
+        
+        this.RequiredInputs = requiredInputs.DistinctBy(i => i.Id).ToFrozenSet();
     }
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
@@ -48,6 +57,12 @@ public abstract class Pipeline
         {
             this.State = PipelineState.Error;
             throw new InvalidOperationException("Pipeline must be restarted before it can be executed again.");
+        }
+        
+        foreach (StepInput input in this.RequiredInputs)
+        {
+            if(!this.Inputs.ContainsKey(input.Id))
+                throw new InvalidOperationException($"Input {input.Id} was not provided to the pipeline before execution.");
         }
 
         this.State = PipelineState.Running;

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -27,6 +27,8 @@ public abstract class Pipeline
         }
     }
 
+    public float CurrentProgress => this._currentStep?.Progress ?? 0;
+
     protected abstract List<Type> StepTypes { get; }
     private List<Step> _steps = [];
     

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -19,7 +19,7 @@ public abstract class Pipeline
     {
         get
         {
-            float completed = this._currentStepIndex / (float)this._steps.Count;
+            float completed = (this._currentStepIndex - 1) / (float)this._steps.Count;
             float currentStep = this._currentStep?.Progress ?? 0f;
             float stepWeight = 1f / this._steps.Count;
             

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -64,13 +64,14 @@ public abstract class Pipeline
                 await step.ExecuteAsync(cancellationToken);
                 cancellationToken.ThrowIfCancellationRequested();
             }
-            catch (Exception ex)
+            catch (TaskCanceledException)
             {
-                if (ex is OperationCanceledException)
-                    this.State = PipelineState.Cancelled;
-                else
-                    this.State = PipelineState.Error;
-
+                this.State = PipelineState.Cancelled;
+                return;
+            }
+            catch (Exception)
+            {
+                this.State = PipelineState.Error;
                 throw;
             }
 

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -44,8 +44,11 @@ public abstract class Pipeline
 
     public async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        if(this.State != PipelineState.NotStarted)
+        if (this.State != PipelineState.NotStarted)
+        {
+            this.State = PipelineState.Error;
             throw new InvalidOperationException("Pipeline must be restarted before it can be executed again.");
+        }
 
         this.State = PipelineState.Running;
         

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -1,0 +1,79 @@
+using System.Diagnostics;
+using System.Reflection;
+using NotEnoughLogs;
+
+using GlobalState = Refresher.Core.State;
+
+namespace Refresher.Core.Pipelines;
+
+public abstract class Pipeline
+{
+    public abstract string Id { get; }
+    public abstract string Name { get; }
+    
+    public PipelineState State { get; private set; } = PipelineState.NotStarted;
+    
+    public float Progress
+    {
+        get
+        {
+            float completed = this._currentStepIndex / (float)this._steps.Count;
+            float currentStep = this._currentStep?.Progress ?? 0f;
+            float stepWeight = 1f / this._steps.Count;
+            
+            return completed + currentStep * stepWeight;
+        }
+    }
+
+    protected abstract List<Type> StepTypes { get; }
+    private List<Step> _steps = [];
+    
+    private byte _currentStepIndex;
+    private Step? _currentStep;
+
+    public void Initialize()
+    {
+        this._steps = new List<Step>(this.StepTypes.Count);
+        foreach (Type type in this.StepTypes)
+        {
+            Debug.Assert(type.IsAssignableTo(typeof(Step)));
+            Step step = (Step)Activator.CreateInstance(type, this)!;
+            this._steps.Add(step);
+        }
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if(this.State != PipelineState.NotStarted)
+            throw new InvalidOperationException("Pipeline must be restarted before it can be executed again.");
+
+        this.State = PipelineState.Running;
+        
+        byte i = 1;
+        foreach (Step step in this._steps)
+        {
+            GlobalState.Logger.LogInfo(LogType.Pipeline, $"Executing {step.GetType().Name}... ({i}/{this._steps.Count})");
+            this._currentStepIndex = i;
+            this._currentStep = step;
+
+            try
+            {
+                await step.ExecuteAsync(cancellationToken);
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            catch (Exception ex)
+            {
+                if (ex is OperationCanceledException)
+                    this.State = PipelineState.Cancelled;
+                else
+                    this.State = PipelineState.Error;
+
+                throw;
+            }
+
+            i++;
+        }
+
+        this.State = PipelineState.Finished;
+    }
+}

--- a/Refresher.Core/Pipelines/PipelineState.cs
+++ b/Refresher.Core/Pipelines/PipelineState.cs
@@ -1,0 +1,10 @@
+namespace Refresher.Core.Pipelines;
+
+public enum PipelineState : byte
+{
+    NotStarted,
+    Running,
+    Finished,
+    Cancelled,
+    Error,
+}

--- a/Refresher.Core/Pipelines/Step.cs
+++ b/Refresher.Core/Pipelines/Step.cs
@@ -5,6 +5,8 @@ public abstract class Step
     protected Pipeline Pipeline { get; }
     public abstract float Progress { get; protected set; }
 
+    public virtual List<StepInput> Inputs { get; } = [];
+
     protected Step(Pipeline pipeline)
     {
         this.Pipeline = pipeline;

--- a/Refresher.Core/Pipelines/Step.cs
+++ b/Refresher.Core/Pipelines/Step.cs
@@ -1,0 +1,14 @@
+namespace Refresher.Core.Pipelines;
+
+public abstract class Step
+{
+    protected Pipeline Pipeline { get; }
+    public abstract float Progress { get; protected set; }
+
+    protected Step(Pipeline pipeline)
+    {
+        this.Pipeline = pipeline;
+    }
+
+    public abstract Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/Refresher.Core/Pipelines/StepInput.cs
+++ b/Refresher.Core/Pipelines/StepInput.cs
@@ -1,0 +1,22 @@
+namespace Refresher.Core.Pipelines;
+
+public class StepInput
+{
+    public string Id { get; init; }
+    public string Name { get; init; }
+
+    public StepInput(string id, string name)
+    {
+        this.Id = id;
+        this.Name = name;
+    }
+
+    public string GetValueFromPipeline(Pipeline pipeline)
+    {
+        bool success = pipeline.Inputs.TryGetValue(this.Id, out string? input);
+        if(!success)
+            throw new Exception($"Input {this.Id} was not provided to the pipeline before execution.");
+
+        return input!;
+    }
+}

--- a/Refresher.Core/Pipelines/Steps/DelayOneSecondStep.cs
+++ b/Refresher.Core/Pipelines/Steps/DelayOneSecondStep.cs
@@ -1,8 +1,8 @@
 namespace Refresher.Core.Pipelines.Steps;
 
-public class ExampleStep : Step
+public class DelayOneSecondStep : Step
 {
-    public ExampleStep(Pipeline pipeline) : base(pipeline)
+    public DelayOneSecondStep(Pipeline pipeline) : base(pipeline)
     {
     }
 

--- a/Refresher.Core/Pipelines/Steps/DelayOneSecondStep.cs
+++ b/Refresher.Core/Pipelines/Steps/DelayOneSecondStep.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Refresher.Core.Pipelines.Steps;
 
 public class DelayOneSecondStep : Step
@@ -10,6 +12,11 @@ public class DelayOneSecondStep : Step
 
     public override async Task ExecuteAsync(CancellationToken cancellationToken = default)
     {
-        await Task.Delay(1000, cancellationToken);
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        while (stopwatch.ElapsedMilliseconds <= 1000)
+        {
+            this.Progress = stopwatch.ElapsedMilliseconds / 1000.0f;
+            await Task.Delay(10, cancellationToken);
+        }
     }
 }

--- a/Refresher.Core/Pipelines/Steps/ExampleInputStep.cs
+++ b/Refresher.Core/Pipelines/Steps/ExampleInputStep.cs
@@ -1,0 +1,21 @@
+namespace Refresher.Core.Pipelines.Steps;
+
+public class ExampleInputStep : Step
+{
+    public ExampleInputStep(Pipeline pipeline) : base(pipeline)
+    {
+    }
+
+    public override float Progress { get; protected set; }
+
+    public override List<StepInput> Inputs { get; } =
+    [
+        new("example-input", "Input"),
+    ];
+
+    public override Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        State.Logger.LogInfo(LogType.Pipeline, $"Input was set to '{this.Inputs[0].GetValueFromPipeline(this.Pipeline)}'");
+        return Task.CompletedTask;
+    }
+}

--- a/Refresher.Core/Pipelines/Steps/ExampleStep.cs
+++ b/Refresher.Core/Pipelines/Steps/ExampleStep.cs
@@ -1,0 +1,15 @@
+namespace Refresher.Core.Pipelines.Steps;
+
+public class ExampleStep : Step
+{
+    public ExampleStep(Pipeline pipeline) : base(pipeline)
+    {
+    }
+
+    public override float Progress { get; protected set; }
+
+    public override async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(1000, cancellationToken);
+    }
+}

--- a/Refresher.Core/State.cs
+++ b/Refresher.Core/State.cs
@@ -7,7 +7,10 @@ namespace Refresher.Core;
 
 public static class State
 {
-    public static readonly Logger Logger = InitializeLogger([new ConsoleSink(), new SentryBreadcrumbSink()]);
+    public static readonly Logger Logger = InitializeLogger([new ConsoleSink(), new EventSink(), new SentryBreadcrumbSink()]);
+
+    public delegate void RefresherLogHandler(RefresherLog log);
+    public static event RefresherLogHandler? Log;
 
     private static Logger InitializeLogger(IEnumerable<ILoggerSink> sinks)
     {
@@ -19,5 +22,10 @@ public static class State
             Behaviour = new DirectLoggingBehaviour(),
             MaxLevel = LogLevel.Trace,
         });
+    }
+
+    internal static void InvokeOnLog(LogLevel level, ReadOnlySpan<char> category, ReadOnlySpan<char> content)
+    {
+        Log?.Invoke(new RefresherLog(level, category.ToString(), content.ToString()));
     }
 }

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -55,11 +55,6 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        ExamplePipeline pipeline = new ExamplePipeline();
-        pipeline.Initialize();
-
-        pipeline.ExecuteAsync().Wait();
-        return;
         InitializeSentry();
         
         if (args.Length > 0)

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -4,6 +4,7 @@ using CommandLine;
 using Eto.Forms;
 using Refresher.CLI;
 using Refresher.Core;
+using Refresher.Core.Pipelines;
 using Refresher.UI;
 
 namespace Refresher;
@@ -54,6 +55,11 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        ExamplePipeline pipeline = new ExamplePipeline();
+        pipeline.Initialize();
+
+        pipeline.ExecuteAsync().Wait();
+        return;
         InitializeSentry();
         
         if (args.Length > 0)

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -18,9 +18,9 @@ public class MainForm : RefresherForm
             new Button((_, _) => this.ShowChild<FilePatchForm>()) { Text = "File Patch (using a .ELF)" },
             new Button((_, _) => this.ShowChild<EmulatorPatchForm>()) { Text = "RPCS3 Patch" },
             new Button((_, _) => this.ShowChild<ConsolePatchForm>()) { Text = "PS3 Patch" },
-            new Button((_, _) => this.ShowChild<PSPSetupForm>()) { Text = "PSP Setup" },
+            new Button((_, _) => this.ShowChild<PSPSetupForm>()) { Text = "PSP Setup" }
             #if DEBUG
-            this.PipelineButton<ExamplePipeline>()
+            ,this.PipelineButton<ExamplePipeline>()
             #endif
         );
 

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -1,5 +1,6 @@
 using Eto.Drawing;
 using Eto.Forms;
+using Refresher.Core.Pipelines;
 
 namespace Refresher.UI;
 
@@ -17,10 +18,16 @@ public class MainForm : RefresherForm
             new Button((_, _) => this.ShowChild<FilePatchForm>()) { Text = "File Patch (using a .ELF)" },
             new Button((_, _) => this.ShowChild<EmulatorPatchForm>()) { Text = "RPCS3 Patch" },
             new Button((_, _) => this.ShowChild<ConsolePatchForm>()) { Text = "PS3 Patch" },
-            new Button((_, _) => this.ShowChild<PSPSetupForm>()) { Text = "PSP Setup" }
+            new Button((_, _) => this.ShowChild<PSPSetupForm>()) { Text = "PSP Setup" },
+            this.PipelineButton<ExamplePipeline>()
         );
 
         layout.Spacing = 5;
         layout.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+    }
+
+    private Button PipelineButton<TPipeline>() where TPipeline : Pipeline, new()
+    {
+        return new Button((_, _) => this.ShowChild<PipelineForm<TPipeline>>()) { Text = typeof(TPipeline).Name };
     }
 }

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -19,7 +19,9 @@ public class MainForm : RefresherForm
             new Button((_, _) => this.ShowChild<EmulatorPatchForm>()) { Text = "RPCS3 Patch" },
             new Button((_, _) => this.ShowChild<ConsolePatchForm>()) { Text = "PS3 Patch" },
             new Button((_, _) => this.ShowChild<PSPSetupForm>()) { Text = "PSP Setup" },
+            #if DEBUG
             this.PipelineButton<ExamplePipeline>()
+            #endif
         );
 
         layout.Spacing = 5;

--- a/Refresher/UI/PatchForm.cs
+++ b/Refresher/UI/PatchForm.cs
@@ -10,8 +10,6 @@ using Refresher.Core;
 using Refresher.Core.Patching;
 using Refresher.Core.Verification;
 using Refresher.Core.Verification.Autodiscover;
-using Refresher.Core.Patching;
-using Sentry;
 using Task = System.Threading.Tasks.Task;
 
 namespace Refresher.UI;

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -1,0 +1,51 @@
+using Eto.Drawing;
+using Eto.Forms;
+using Refresher.Core.Pipelines;
+
+namespace Refresher.UI;
+
+public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline, new()
+{
+    private TPipeline? _pipeline;
+    
+    private ProgressBar _progressBar;
+    
+    public PipelineForm() : base(typeof(TPipeline).Name, new Size(700, 1), false)
+    {
+        this.InitializePipeline();
+        
+        this.Content = new StackLayout([
+            new Button(this.ExecutePipeline),
+            this._progressBar = new ProgressBar(),
+        ]);
+
+        Thread progressThread = new(() =>
+        {
+            while (!this.IsDisposed && !Application.Instance.IsDisposed)
+            {
+                Application.Instance.Invoke(() =>
+                {
+                    this._progressBar.Value = (int)((this._pipeline?.Progress ?? 0) * 100);
+                    this._progressBar.Enabled = this._pipeline?.State == PipelineState.Running;
+                });
+                Thread.Sleep(100);
+            }
+        });
+        
+        progressThread.Start();
+    }
+
+    private void InitializePipeline()
+    {
+        this._pipeline = new TPipeline();
+        this._pipeline.Initialize();
+    }
+
+    private void ExecutePipeline(object? sender, EventArgs e)
+    {
+        Task.Run(async () =>
+        {
+            await this._pipeline.ExecuteAsync();
+        });
+    }
+}

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -109,6 +109,11 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
             return;
         }
         
+        if (this._pipeline.State is PipelineState.Cancelled or PipelineState.Error or PipelineState.Finished)
+        {
+            this.InitializePipeline();
+        }
+        
         foreach (TableRow row in this._formLayout.Rows)
         {
             string id = row.Cells[0].Control.ToolTip;

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -1,6 +1,7 @@
 using Eto.Drawing;
 using Eto.Forms;
 using Refresher.Core;
+using Refresher.Core.Logging;
 using Refresher.Core.Pipelines;
 
 namespace Refresher.UI;
@@ -36,6 +37,8 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
         
         this.InitializePipeline();
         this.InitializeFormStateUpdater();
+        
+        State.Log += this.OnLog;
     }
 
     private void UpdateFormState()
@@ -105,5 +108,10 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
         }, this._cts?.Token ?? default);
         
         this.UpdateFormState();
+    }
+    
+    private void OnLog(RefresherLog log)
+    {
+        this._messages.Items.Add($"[{log.Level}] [{log.Category}] {log.Content}");
     }
 }

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -11,6 +11,7 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
     private TPipeline? _pipeline;
 
     private readonly Button _button;
+    private readonly ProgressBar _currentProgressBar;
     private readonly ProgressBar _progressBar;
     private readonly ListBox _messages;
     
@@ -31,6 +32,7 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
             Panel2 = new StackLayout([
                 this._messages = new ListBox { Height = 200 },
                 this._button = new Button(this.OnButtonClick) { Text = "Execute" },
+                this._currentProgressBar = new ProgressBar(),
                 this._progressBar = new ProgressBar(),
             ])
             {
@@ -50,7 +52,8 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
     private void UpdateFormState()
     {
         this._progressBar.Value = (int)((this._pipeline?.Progress ?? 0) * 100);
-        this._progressBar.Enabled = this._pipeline?.State == PipelineState.Running;
+        this._currentProgressBar.Value = (int)(this._pipeline?.CurrentProgress * 100 ?? 0);
+        this._currentProgressBar.Enabled = this._progressBar.Enabled = this._pipeline?.State == PipelineState.Running;
         this._progressBar.ToolTip = this._pipeline?.State.ToString() ?? "Uninitialized";
 
         this._button.Text = this._pipeline?.State switch

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -8,44 +8,62 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
 {
     private TPipeline? _pipeline;
     
-    private ProgressBar _progressBar;
+    private readonly Label _stateLabel;
+    private readonly ProgressBar _progressBar;
     
     public PipelineForm() : base(typeof(TPipeline).Name, new Size(700, 1), false)
     {
-        this.InitializePipeline();
-        
         this.Content = new StackLayout([
-            new Button(this.ExecutePipeline),
+            this._stateLabel = new Label(),
+            new Button(this.ExecutePipeline) { Text = "Execute" },
             this._progressBar = new ProgressBar(),
-        ]);
+        ])
+        {
+            Padding = new Padding(0, 10, 0, 0),
+            Spacing = 5,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            VerticalContentAlignment = VerticalAlignment.Bottom,
+        };
+        
+        this.InitializePipeline();
 
         Thread progressThread = new(() =>
         {
             while (!this.IsDisposed && !Application.Instance.IsDisposed)
             {
-                Application.Instance.Invoke(() =>
-                {
-                    this._progressBar.Value = (int)((this._pipeline?.Progress ?? 0) * 100);
-                    this._progressBar.Enabled = this._pipeline?.State == PipelineState.Running;
-                });
-                Thread.Sleep(100);
+                Application.Instance.Invoke(this.UpdateFormState);
+                Thread.Sleep(this._pipeline?.State == PipelineState.Running ? 50 : 250);
             }
         });
         
         progressThread.Start();
     }
 
+    private void UpdateFormState()
+    {
+        this._progressBar.Value = (int)((this._pipeline?.Progress ?? 0) * 100);
+        this._progressBar.Enabled = this._pipeline?.State == PipelineState.Running;
+        this._stateLabel.Text = this._pipeline?.State.ToString() ?? "Uninitialized";
+    }
+
     private void InitializePipeline()
     {
         this._pipeline = new TPipeline();
         this._pipeline.Initialize();
+        
+        this.UpdateFormState();
     }
 
     private void ExecutePipeline(object? sender, EventArgs e)
     {
+        if (this._pipeline == null)
+            return;
+        
         Task.Run(async () =>
         {
             await this._pipeline.ExecuteAsync();
         });
+        
+        this.UpdateFormState();
     }
 }

--- a/Refresher/UI/RefresherForm.cs
+++ b/Refresher/UI/RefresherForm.cs
@@ -13,14 +13,10 @@ public abstract class RefresherForm : Form
 {
     protected RefresherForm(string subtitle, Size size, bool padBottom = true)
     {
-        this.Title = "Refresher";
-        if (!string.IsNullOrWhiteSpace(subtitle))
-        {
-            this.Title += " - " + subtitle;
-        }
+        UpdateSubtitle(subtitle);
 
         this.ClientSize = size;
-        this.AutoSize = true;
+        // this.AutoSize = true;
         this.Padding = new Padding(10, 10, 10, padBottom ? 10 : 0);
         
         this.Icon = Icon.FromResource("refresher.ico");
@@ -44,11 +40,20 @@ public abstract class RefresherForm : Form
         if (close) this.Visible = false;
     }
 
-    public class RefresherMenuBar : MenuBar
+    protected void UpdateSubtitle(string subtitle)
+    {
+        this.Title = "Refresher";
+        if (!string.IsNullOrWhiteSpace(subtitle))
+        {
+            this.Title += " - " + subtitle;
+        }
+    }
+
+    private class RefresherMenuBar : MenuBar
     {
         public RefresherMenuBar() {
-            Style = "MenuBar";
-            IncludeSystemItems = MenuBarSystemItems.All;
+            this.Style = "MenuBar";
+            this.IncludeSystemItems = MenuBarSystemItems.All;
         }
     }
 }


### PR DESCRIPTION
This PR implements the base framework for the new method of writing patchers and other functionality within Refresher. Everything is planned to be ported to this system.

Essentially, a pipeline defines a series of steps that Refresher will take. This allows us to easily re-use otherwise redundant code instead of scattering things across UI code.

The take-away with this system is that pipelines DO NOT depend on any UI code, making them frontend agnostic and easy to work with. They also run asynchronously in the background, so we no longer have the problem of locking up the main UI thread.