### PR TITLE
Windows distribution refactor

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Publish for Windows x64
       if: matrix.os == 'windows-latest'
       shell: bash
-      run: dotnet publish -c Release -r win-x64 --self-contained Refresher //p:Version=${VERSION}
+      run: dotnet publish -c Release -r win-x64 --no-self-contained Refresher //p:Version=${VERSION}
 
     - name: Publish for macOS x64
       if: matrix.os == 'macos-latest'
@@ -125,7 +125,7 @@ jobs:
       uses: actions/upload-artifact@v3.1.1
       with:
           name: "Refresher for Windows x64"
-          path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
+          path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/Refresher.exe"
           if-no-files-found: error
           retention-days: 30
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,6 @@ jobs:
             cd ${{steps.download.outputs.download-path}}
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64/Refresher.exe ./Refresher_for_Windows_x64.exe
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64/*.tar.gz .
-            mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_arm/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_arm64/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_macOS/*.tar.gz .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Publish for Windows x64
         if: matrix.os == 'windows-latest'
         shell: bash
-        run: dotnet publish -c Release -r win-x64 --self-contained Refresher //p:Version=${VERSION}
+        run: dotnet publish -c Release -r win-x64 --no-self-contained Refresher //p:Version=${VERSION}
 
       - name: Publish for macOS x64
         if: matrix.os == 'macos-latest'
@@ -126,7 +126,7 @@ jobs:
         uses: actions/upload-artifact@v3.1.3
         with:
             name: "Refresher_for_Windows_x64"
-            path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/"
+            path: "Refresher/bin/Release/net8.0-windows/win-x64/publish/Refresher.exe"
             if-no-files-found: error
             retention-days: 1
 
@@ -151,10 +151,9 @@ jobs:
 
       - name: Create zip files
         run: |
-            cd ${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64
-            zip -r "${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64.zip" .
-
             cd ${{steps.download.outputs.download-path}}
+            mv ${{steps.download.outputs.download-path}}/Refresher_for_Windows_x64/Refresher.exe ./Refresher_for_Windows_x64.exe
+            mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_x64/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_arm/*.tar.gz .
             mv ${{steps.download.outputs.download-path}}/Refresher_for_Linux_arm64/*.tar.gz .
@@ -171,3 +170,4 @@ jobs:
           artifacts: |
             *.zip
             *.tar.gz
+            Refresher_for_Windows_x64.exe

--- a/Refresher.Core/Refresher.Core.csproj
+++ b/Refresher.Core/Refresher.Core.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
     
     <ItemGroup>

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -35,6 +35,8 @@
         <RuntimeIdentifiers Condition="$(IsOSX)">osx-x64;osx-arm64</RuntimeIdentifiers>
         <ApplicationIcon>Resources\refresher.ico</ApplicationIcon>
         <BuiltInComInteropSupport Condition="'$(TargetFramework)' == 'net8.0-windows'">true</BuiltInComInteropSupport>
+        <IncludeNativeLibrariesForSelfExtract Condition="$(IsWindows)">true</IncludeNativeLibrariesForSelfExtract>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
- Publish as a non-self-contained binary
    This excludes the .NET Desktop runtime from the download, instead prompting the user to download it separately. This also removes WPF DLLs from the output.
- Include debugging symbols and native libraries inside the main executable
    This bundles everything into one self-extracting executable using the [`IncludeNativeLibrariesForSelfExtract`](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli#native-libraries) property on Windows. This simply drops a DLL to a temp folder so there doesn't have to be a scetool.dll next to the executable:
![image](https://github.com/user-attachments/assets/885d06a8-7a57-470e-b59f-db3a56148106)
    Managed DLLs are handled as normal; they are in the exe itself.
- Remove the .zip container from the release artifact
    Since we only have the .exe to work with, there's no need to package things in a zip file.

In total, this brings the total size down from 64.9MB to 6.1MB. The setup process on a fresh copy of Windows w/o .NET isn't too complicated:

https://github.com/user-attachments/assets/18e1905f-283b-4e89-a6e5-fcf8ac9df39a


