### PR TITLE
Fix Refresher becoming a zombie process on closing a PipelineForm child window

### DIFF
--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -480,5 +481,11 @@ public class PipelineForm<TPipeline> : RefresherForm where TPipeline : Pipeline,
                 MessageBox.Show(log.Content, $"{log.Category} {log.Level.ToString()}", MessageBoxType.Error);
             }
         });
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        Environment.Exit(0);
+        base.OnClosing(e);
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/13a06172-4ff0-4f27-a930-738bf5bf85f1)
