### PR TITLE
Initial support for deploying Patchwork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "External/SPRXPatcher"]
+	path = External/SPRXPatcher
+	url = https://github.com/NotNite/SPRXPatcher

--- a/Refresher.Core/Accessors/PatchAccessor.cs
+++ b/Refresher.Core/Accessors/PatchAccessor.cs
@@ -58,6 +58,24 @@ public abstract class PatchAccessor
             throw;
         }
     }
+    
+    public static async Task TryAsync(Func<Task> action)
+    {
+        try
+        {
+            await action();
+        }
+        catch (TargetInvocationException targetInvocationException)
+        {
+            CatchAccessorException(targetInvocationException.InnerException!);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            CatchAccessorException(ex);
+            throw;
+        }
+    }
 
     private static void CatchAccessorException(Exception ex)
     {

--- a/Refresher.Core/LogType.cs
+++ b/Refresher.Core/LogType.cs
@@ -17,5 +17,6 @@ public enum LogType : byte
     PS3,
     Vita,
     RPCS3,
-    Pipeline
+    Pipeline,
+    Patchwork
 }

--- a/Refresher.Core/Pipelines/CommonStepInputs.cs
+++ b/Refresher.Core/Pipelines/CommonStepInputs.cs
@@ -26,6 +26,11 @@ public static class CommonStepInputs
         Placeholder = "192.168.1.123",
     };
     
+    internal static readonly StepInput LobbyPassword = new("lobby-password", "Lobby Password")
+    {
+        Placeholder = "(leave empty to randomize)",
+    };
+    
     // TODO: Cache the last used location for easier entry
     private static string? DetermineDefaultRpcs3Path()
     {

--- a/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
@@ -31,6 +31,7 @@ public class LbpPS3PatchPipeline : Pipeline
         typeof(EncryptGameEbootStep),
         typeof(BackupGameEbootBeforeReplaceStep),
         typeof(UploadPatchworkSprxStep),
+        typeof(UploadPatchworkConfigurationStep),
         typeof(UploadGameEbootStep),
     ];
 }

--- a/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
@@ -1,0 +1,36 @@
+﻿using Refresher.Core.Pipelines.Steps;
+
+namespace Refresher.Core.Pipelines.Lbp;
+
+public class LbpPS3PatchPipeline : Pipeline
+{
+    public override string Id => "lbp-ps3-patch";
+    public override string Name => "LBP PS3 Patch";
+
+    protected override Type SetupAccessorStepType => typeof(SetupPS3AccessorStep);
+    public override bool ReplacesEboot => true;
+
+    public override string GuideLink => "https://docs.littlebigrefresh.com/ps3";
+
+    protected override List<Type> StepTypes =>
+    [
+        // // Info gathering stage
+        // typeof(ValidateGameStep),
+        // typeof(DownloadParamSfoStep),
+        // typeof(DownloadGameEbootStep),
+        // typeof(ReadEbootContentIdStep),
+        // typeof(DownloadGameLicenseStep),
+        // typeof(GetConsoleIdpsStep),
+        //
+        // // Decryption and patch stage
+        // typeof(PrepareSceToolStep),
+        // typeof(DecryptGameEbootStep),
+        // typeof(PrepareEbootPatcherAndVerifyStep),
+        // typeof(ApplyPatchToEbootStep),
+        //
+        // // Encryption and upload stage
+        // typeof(EncryptGameEbootStep),
+        // typeof(BackupGameEbootBeforeReplaceStep),
+        // typeof(UploadGameEbootStep),
+    ];
+}

--- a/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
@@ -14,23 +14,23 @@ public class LbpPS3PatchPipeline : Pipeline
 
     protected override List<Type> StepTypes =>
     [
-        // // Info gathering stage
-        // typeof(ValidateGameStep),
-        // typeof(DownloadParamSfoStep),
-        // typeof(DownloadGameEbootStep),
-        // typeof(ReadEbootContentIdStep),
-        // typeof(DownloadGameLicenseStep),
-        // typeof(GetConsoleIdpsStep),
-        //
-        // // Decryption and patch stage
-        // typeof(PrepareSceToolStep),
-        // typeof(DecryptGameEbootStep),
-        // typeof(PrepareEbootPatcherAndVerifyStep),
-        // typeof(ApplyPatchToEbootStep),
-        //
-        // // Encryption and upload stage
-        // typeof(EncryptGameEbootStep),
-        // typeof(BackupGameEbootBeforeReplaceStep),
-        // typeof(UploadGameEbootStep),
+        // Info gathering stage
+        typeof(ValidateGameStep),
+        typeof(DownloadParamSfoStep),
+        typeof(DownloadGameEbootStep),
+        typeof(ReadEbootContentIdStep),
+        typeof(DownloadGameLicenseStep),
+        typeof(GetConsoleIdpsStep),
+        
+        // Decryption and patch stage
+        typeof(PrepareSceToolStep),
+        typeof(DecryptGameEbootStep),
+        typeof(ApplySprxPatchToEbootStep),
+        
+        // Encryption and upload stage
+        typeof(EncryptGameEbootStep),
+        typeof(BackupGameEbootBeforeReplaceStep),
+        typeof(UploadPatchworkSprxStep),
+        typeof(UploadGameEbootStep),
     ];
 }

--- a/Refresher.Core/Pipelines/PS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/PS3PatchPipeline.cs
@@ -5,7 +5,7 @@ namespace Refresher.Core.Pipelines;
 public class PS3PatchPipeline : Pipeline
 {
     public override string Id => "ps3-patch";
-    public override string Name => "PS3 Patch";
+    public override string Name => "PS3 Patch (any game)";
 
     protected override Type SetupAccessorStepType => typeof(SetupPS3AccessorStep);
     public override bool ReplacesEboot => true;

--- a/Refresher.Core/Pipelines/RPCS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/RPCS3PatchPipeline.cs
@@ -5,7 +5,7 @@ namespace Refresher.Core.Pipelines;
 public class RPCS3PatchPipeline : Pipeline
 {
     public override string Id => "rpcs3-patch";
-    public override string Name => "RPCS3 Patch";
+    public override string Name => "RPCS3 Patch (any game)";
 
     protected override Type SetupAccessorStepType => typeof(SetupEmulatorAccessorStep);
     

--- a/Refresher.Core/Pipelines/Steps/ApplySprxPatchToEbootStep.cs
+++ b/Refresher.Core/Pipelines/Steps/ApplySprxPatchToEbootStep.cs
@@ -24,7 +24,8 @@ public class ApplySprxPatchToEbootStep : Step
         
         elf.SprxPath = "/dev_hdd0/plugins/patchwork.sprx";
 
-        await using FileStream writeStream = File.OpenWrite(decryptedEbootPath);
+        // writing requires read permissions for PPU hash calculation
+        await using FileStream writeStream = File.Open(decryptedEbootPath, FileMode.Open, FileAccess.ReadWrite);
         elf.Write(writeStream);
     }
 }

--- a/Refresher.Core/Pipelines/Steps/ApplySprxPatchToEbootStep.cs
+++ b/Refresher.Core/Pipelines/Steps/ApplySprxPatchToEbootStep.cs
@@ -1,0 +1,30 @@
+﻿using SPRXPatcher.Elf;
+
+namespace Refresher.Core.Pipelines.Steps;
+
+public class ApplySprxPatchToEbootStep : Step
+{
+    public ApplySprxPatchToEbootStep(Pipeline pipeline) : base(pipeline)
+    {}
+
+    public override float Progress { get; protected set; }
+    public override async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        string? decryptedEbootPath = this.Game?.DecryptedEbootPath;
+        if (decryptedEbootPath == null)
+            throw new InvalidOperationException("We haven't decrypted the eboot yet");
+
+        FileStream stream = File.OpenRead(decryptedEbootPath);
+        ElfFile elf = new(stream);
+        // dispose early to avoid errors while writing in-place
+        // above ctor consumes whole stream without reading again
+        await stream.DisposeAsync();
+        
+        this.Progress = 0.5f;
+        
+        elf.SprxPath = "/dev_hdd0/plugins/patchwork.sprx";
+
+        await using FileStream writeStream = File.OpenWrite(decryptedEbootPath);
+        elf.Write(writeStream);
+    }
+}

--- a/Refresher.Core/Pipelines/Steps/UploadPatchworkConfigurationStep.cs
+++ b/Refresher.Core/Pipelines/Steps/UploadPatchworkConfigurationStep.cs
@@ -1,0 +1,58 @@
+﻿using System.Text;
+using Refresher.Core.Accessors;
+
+namespace Refresher.Core.Pipelines.Steps;
+
+public class UploadPatchworkConfigurationStep : Step
+{
+    public UploadPatchworkConfigurationStep(Pipeline pipeline) : base(pipeline)
+    {}
+    
+    public override List<StepInput> Inputs =>
+    [
+        CommonStepInputs.ServerUrl,
+        CommonStepInputs.LobbyPassword,
+    ];
+
+    public override float Progress { get; protected set; }
+    public override async Task ExecuteAsync(CancellationToken ct = default)
+    {
+        string? lobbyPassword = this.Pipeline.Inputs["lobby-password"];
+        if (string.IsNullOrWhiteSpace(lobbyPassword))
+            lobbyPassword = null;
+        
+        await this.UploadConfigValue("patchwork_lobby_password.txt", lobbyPassword, ct);
+        this.Progress = 0.33f;
+        
+        await this.UploadConfigValue("patchwork_url.txt", this.Pipeline.Inputs["url"], ct);
+        this.Progress = 0.66f;
+        
+        string? customDigest = this.Pipeline.AutoDiscover?.UsesCustomDigestKey ?? false
+            ? "CustomServerDigest"
+            : null;
+        
+        await this.UploadConfigValue("patchwork_digest.txt", customDigest, ct);
+        
+        this.Progress = 1f;
+    }
+
+    private async Task UploadConfigValue(string filename, string? value, CancellationToken ct = default)
+    {
+        await PatchAccessor.TryAsync(async () =>
+        {
+            string configPath = "/dev_hdd0/tmp/" + filename;
+            
+            if (this.Pipeline.Accessor!.FileExists(configPath))
+                this.Pipeline.Accessor.RemoveFile(configPath);
+
+            if (value == null)
+                return;
+
+            await using Stream writeStream = this.Pipeline.Accessor.OpenWrite(configPath);
+            await using Stream readStream = new MemoryStream(Encoding.UTF8.GetBytes(value));
+
+            await readStream.CopyToAsync(writeStream, ct);
+            await writeStream.FlushAsync(ct);
+        });
+    }
+}

--- a/Refresher.Core/Pipelines/Steps/UploadPatchworkSprxStep.cs
+++ b/Refresher.Core/Pipelines/Steps/UploadPatchworkSprxStep.cs
@@ -1,0 +1,42 @@
+﻿using System.Reflection;
+using Refresher.Core.Accessors;
+
+namespace Refresher.Core.Pipelines.Steps;
+
+public class UploadPatchworkSprxStep : Step
+{
+    public UploadPatchworkSprxStep(Pipeline pipeline) : base(pipeline)
+    {}
+
+    public override float Progress { get; protected set; }
+    public override async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        await PatchAccessor.TryAsync(async () =>
+        {
+            const string sprxName = "patchwork.sprx";
+            const string sprxPath = "/dev_hdd0/plugins/" + sprxName;
+            
+            if (this.Pipeline.Accessor!.FileExists(sprxPath))
+                this.Pipeline.Accessor.RemoveFile(sprxPath);
+            
+            this.Progress = 0.5f;
+
+            if (File.Exists(sprxName))
+            {
+                State.Logger.LogInfo(Patchwork, "Found custom patchwork.sprx next to exe, uploading that instead");
+                this.Pipeline.Accessor.UploadFile(sprxName, sprxPath);
+            }
+            else
+            {
+                await using Stream writeStream = this.Pipeline.Accessor.OpenWrite(sprxPath);
+                await using Stream? readStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(sprxName);
+
+                if (readStream == null)
+                    throw new InvalidOperationException("The sprx file is missing from this build! Tell a developer.");
+
+                await readStream.CopyToAsync(writeStream, cancellationToken);
+                await writeStream.FlushAsync(cancellationToken);
+            }
+        });
+    }
+}

--- a/Refresher.Core/Refresher.Core.csproj
+++ b/Refresher.Core/Refresher.Core.csproj
@@ -20,7 +20,7 @@
     </ItemGroup>
     
     <ItemGroup>
-        <EmbeddedResource Include="Resources/patchwork.sprx">
+        <EmbeddedResource Include="Resources/patchwork.sprx" Condition="Exists('Resources/patchwork.sprx')">
             <LogicalName>patchwork.sprx</LogicalName>
         </EmbeddedResource>
     </ItemGroup>

--- a/Refresher.Core/Refresher.Core.csproj
+++ b/Refresher.Core/Refresher.Core.csproj
@@ -14,5 +14,15 @@
         <PackageReference Include="ELFSharp" Version="2.17.3" />
         <PackageReference Include="Sentry" Version="4.4.0" />
     </ItemGroup>
+    
+    <ItemGroup>
+      <ProjectReference Include="..\External\SPRXPatcher\SPRXPatcher\SPRXPatcher.csproj" />
+    </ItemGroup>
+    
+    <ItemGroup>
+        <EmbeddedResource Include="Resources/patchwork.sprx">
+            <LogicalName>patchwork.sprx</LogicalName>
+        </EmbeddedResource>
+    </ItemGroup>
 
 </Project>

--- a/Refresher.sln
+++ b/Refresher.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresher.Core", "Refresher
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Refresher.AndroidApp", "Refresher.AndroidApp\Refresher.AndroidApp.csproj", "{ADE97BEF-7886-496A-AA8F-7B7504ED931C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "External", "External", "{71B14553-E495-4197-9DE3-DB573C6F5CA2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SPRXPatcher", "External\SPRXPatcher\SPRXPatcher\SPRXPatcher.csproj", "{B49FCFA3-89F2-4B00-A512-711A68DA93D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +34,12 @@ Global
 		{ADE97BEF-7886-496A-AA8F-7B7504ED931C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADE97BEF-7886-496A-AA8F-7B7504ED931C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADE97BEF-7886-496A-AA8F-7B7504ED931C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B49FCFA3-89F2-4B00-A512-711A68DA93D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B49FCFA3-89F2-4B00-A512-711A68DA93D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B49FCFA3-89F2-4B00-A512-711A68DA93D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B49FCFA3-89F2-4B00-A512-711A68DA93D6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B49FCFA3-89F2-4B00-A512-711A68DA93D6} = {71B14553-E495-4197-9DE3-DB573C6F5CA2}
 	EndGlobalSection
 EndGlobal

--- a/Refresher.sln.DotSettings
+++ b/Refresher.sln.DotSettings
@@ -11,6 +11,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LBP/@EntryIndexedValue">LBP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PS/@EntryIndexedValue">PS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PSP/@EntryIndexedValue">PSP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RPCS/@EntryIndexedValue">RPCS</s:String>
 	<s:Boolean x:Key="/Default/Environment/Editor/UseCamelHumps/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Allefresher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Asdf/@EntryIndexedValue">True</s:Boolean>
@@ -29,5 +30,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reverify/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RFSH/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=RPCS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sprx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=USRDIR/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=webman/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -1,6 +1,7 @@
 using Eto.Drawing;
 using Eto.Forms;
 using Refresher.Core.Pipelines;
+using Refresher.Core.Pipelines.Lbp;
 
 namespace Refresher.UI;
 
@@ -16,9 +17,13 @@ public class MainForm : RefresherForm
         // ReSharper disable once RedundantExplicitParamsArrayCreation
         ([
             new Label { Text = "Welcome to Refresher! Please pick a patching method to continue." },
+            new Label { Text = "LittleBigPlanet:" },
+            this.PipelineButton<LbpPS3PatchPipeline>("Patch LBP1/2/3 for PS3"),
+            
+            new Label { Text = "General (for non-LBP games):" },
             new Button((_, _) => this.ShowChild<FilePatchForm>()) { Text = "File Patch (using a .ELF)" },
-            this.PipelineButton<RPCS3PatchPipeline>("Patch an RPCS3 game"),
-            this.PipelineButton<PS3PatchPipeline>("Patch a PS3 game"),
+            this.PipelineButton<RPCS3PatchPipeline>("Patch any RPCS3 game"),
+            this.PipelineButton<PS3PatchPipeline>("Patch any PS3 game"),
             #if DEBUG
             new Label { Text = "Debugging options:" },
             this.PipelineButton<ExamplePipeline>("Example Pipeline"),

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
- Only supports patching for PS3 for now
- Uses SPRXPatcher to tell games to immediately load patchwork.sprx
  Technically, we've been using `/dev_hdd0/tmp` to store the plugin but I think `/dev_hdd0/plugins` makes more sense. Configs can stay in `/dev_hdd0/tmp` though.
- The SPRX is not included in the tree for now until explicit agreement to do so. You can drop it in `Refresh.Core/Resources` or next to the built .exe file to test with.