### PR TITLE
Support for Velopack on Windows and Linux

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,10 +33,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: dotnet publish -c Release -r linux-x64 --self-contained Refresher /p:Version=${VERSION}
       
-    - name: Publish for Linux ARM
-      if: matrix.os == 'ubuntu-latest'
-      run: dotnet publish -c Release -r linux-arm --self-contained Refresher /p:Version=${VERSION}
-      
     - name: Publish for Linux ARM64
       if: matrix.os == 'ubuntu-latest'
       run: dotnet publish -c Release -r linux-arm64 --self-contained Refresher /p:Version=${VERSION}
@@ -96,11 +92,6 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       working-directory: Refresher/bin/Release/net9.0/linux-x64/publish/
       run: tar -cvf ../../../../../../Refresher-x64.tar *
-
-    - name: 'Tar Linux ARM'
-      if: matrix.os == 'ubuntu-latest'
-      working-directory: Refresher/bin/Release/net9.0/linux-arm/publish/
-      run: tar -cvf ../../../../../../Refresher-arm.tar *
       
     - name: 'Tar Linux ARM64'
       if: matrix.os == 'ubuntu-latest'
@@ -113,15 +104,6 @@ jobs:
       with:
           name: "Refresher for Linux x64"
           path: "Refresher-x64.tar"
-          if-no-files-found: error
-          retention-days: 30
-
-    - name: Upload Linux ARM build
-      if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v4
-      with:
-          name: "Refresher for Linux ARM"
-          path: "Refresher-arm.tar"
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: dotnet publish -c Release -r linux-x64 --self-contained Refresher /p:Version=${VERSION} -o publish/
 
-      - name: Publish for Linux ARM
-        if: matrix.os == 'ubuntu-latest'
-        run: dotnet publish -c Release -r linux-arm --self-contained Refresher /p:Version=${VERSION} -o publish/
-
       - name: Publish for Linux ARM64
         if: matrix.os == 'ubuntu-latest'
         run: dotnet publish -c Release -r linux-arm64 --self-contained Refresher /p:Version=${VERSION} -o publish/
@@ -98,12 +94,6 @@ jobs:
         shell: bash
         run: |
             vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
-            
-      - name: Run vpk pack for Linux ARM
-        if: matrix.os == 'ubuntu-latest'
-        shell: bash
-        run: |
-            vpk pack --runtime linux-arm --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM64
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,19 +90,19 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-            vpk pack --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --channel windows-x64 --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux x64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-            vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --channel linux-x64 --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-            vpk pack --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --channel linux-arm64 --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Upload velopack build to GitHub
         if: matrix.os != 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
         run: |
             vpk pack --channel windows-x64 --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
-            vpk upload github --channel windows-arm64 --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
+            vpk upload github --channel windows-x64 --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
             
       - name: Run vpk pack for Linux x64
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
           prerelease: false
           draft: true
           generateReleaseNotes: true
+          allowUpdates: true
           bodyFile: "RELEASE_NOTES.md"
           artifacts: |
             *.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,26 +89,31 @@ jobs:
             
       - name: Run vpk pack for Windows x64
         if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
             vpk pack --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux x64
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: |
-            vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: |
             vpk pack --runtime linux-arm --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM64
         if: matrix.os == 'ubuntu-latest'
+        shell: bash
         run: |
             vpk pack --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Upload velopack build to GitHub
         if: matrix.os != 'macos-latest'
+        shell: bash
         run: vpk upload github --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION
 
       - name: Upload macOS universal2 build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,25 +91,25 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-            vpk pack --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux x64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-            vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-            vpk pack --runtime linux-arm --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --runtime linux-arm --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Run vpk pack for Linux ARM64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-            vpk pack --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir .\publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk pack --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
             
       - name: Upload velopack build to GitHub
         if: matrix.os != 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,23 +91,21 @@ jobs:
         shell: bash
         run: |
             vpk pack --channel windows-x64 --framework net9.0-x64-desktop --runtime win7-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher.exe --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk upload github --channel windows-arm64 --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
             
       - name: Run vpk pack for Linux x64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
             vpk pack --channel linux-x64 --runtime linux-x64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
+            vpk upload github --channel linux-x64 --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
             
       - name: Run vpk pack for Linux ARM64
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
             vpk pack --channel linux-arm64 --runtime linux-arm64 --packId Refresher --packVersion $VERSION --packDir ./publish --mainExe Refresher --packTitle Refresher --packAuthors LittleBigRefresh
-            
-      - name: Upload velopack build to GitHub
-        if: matrix.os != 'macos-latest'
-        shell: bash
-        run: vpk upload github --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
+            vpk upload github --channel linux-arm64 --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload macOS universal2 build
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "*"
 
+permissions:
+    contents: write
+
 jobs:
   build:
     strategy:
@@ -104,7 +107,7 @@ jobs:
       - name: Upload velopack build to GitHub
         if: matrix.os != 'macos-latest'
         shell: bash
-        run: vpk upload github --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION
+        run: vpk upload github --repoUrl https://github.com/${{ github.repository }} --merge --releaseName v$VERSION --tag v$VERSION --token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload macOS universal2 build
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,5 +140,7 @@ jobs:
           generateReleaseNotes: true
           allowUpdates: true
           bodyFile: "RELEASE_NOTES.md"
+          omitBody: 'false'
+          omitBodyDuringUpdate: 'false'
           artifacts: |
             *.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+[Pp]ublish/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -6,6 +6,8 @@ using Refresher.CLI;
 using Refresher.Core;
 using Refresher.Core.Logging;
 using Refresher.UI;
+using Velopack;
+using Velopack.Logging;
 
 namespace Refresher;
 
@@ -18,6 +20,11 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        VelopackApp
+            .Build()
+            .SetLogger(new ConsoleVelopackLogger())
+            .Run();
+        
         State.InitializeLogger([new ConsoleSink(), new EventSink(), new SentryBreadcrumbSink()]);
         State.InitializeSentry();
         

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -53,6 +53,7 @@
       <EmbeddedResource Include="Resources\refresher.ico" LogicalName="refresher.ico" />
       <PackageReference Include="Sentry" Version="4.4.0" />
       <Content Include="Resources/refresher.icns" Link="refresher.icns" Condition="$(IsOSX)" />
+      <PackageReference Include="Velopack" Version="0.0.1298" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Refresher/Refresher.csproj
+++ b/Refresher/Refresher.csproj
@@ -45,11 +45,11 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
-      <PackageReference Include="Eto.Forms" Version="2.8.3" />
+      <PackageReference Include="Eto.Forms" Version="2.9.0" />
       <!-- This could be IsLinux, but GTK is available on basically everything, so might as well use it as the true default -->
-      <PackageReference Condition="!$(IsWindows) And !$(IsOSX)" Include="Eto.Platform.Gtk" Version="2.8.3" />
-      <PackageReference Condition="$(IsOSX)" Include="Eto.Platform.Mac64" Version="2.8.3" />
-      <PackageReference Condition="$(IsWindows)" Include="Eto.Platform.Wpf" Version="2.8.3" />
+      <PackageReference Condition="!$(IsWindows) And !$(IsOSX)" Include="Eto.Platform.Gtk" Version="2.9.0" />
+      <PackageReference Condition="$(IsOSX)" Include="Eto.Platform.Mac64" Version="2.9.0" />
+      <PackageReference Condition="$(IsWindows)" Include="Eto.Platform.Wpf" Version="2.9.0" />
       <EmbeddedResource Include="Resources\refresher.ico" LogicalName="refresher.ico" />
       <PackageReference Include="Sentry" Version="4.4.0" />
       <Content Include="Resources/refresher.icns" Link="refresher.icns" Condition="$(IsOSX)" />

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -2,6 +2,9 @@ using Eto.Drawing;
 using Eto.Forms;
 using Refresher.Core.Pipelines;
 using Refresher.Core.Pipelines.Lbp;
+using Velopack;
+using Velopack.Exceptions;
+using Velopack.Sources;
 
 namespace Refresher.UI;
 
@@ -10,6 +13,23 @@ namespace Refresher.UI;
 /// </summary>
 public class MainForm : RefresherForm
 {
+    private readonly Label _updateStatusLabel;
+
+    private readonly UpdateManager _velo = new(new GithubSource("https://github.com/LittleBigRefresh/Refresher", null, false));
+    private UpdateInfo? _updateInfo;
+
+    private string UpdateStatus
+    {
+        get => this._updateStatusLabel.Text;
+        set
+        {
+            Application.Instance.Invoke(() =>
+            {
+                this._updateStatusLabel.Text = value;
+            });
+        }
+    }
+
     public MainForm() : base(string.Empty, new Size(450, -1))
     {
         StackLayout layout;
@@ -17,6 +37,7 @@ public class MainForm : RefresherForm
         // ReSharper disable once RedundantExplicitParamsArrayCreation
         ([
             new Label { Text = "Welcome to Refresher! Please pick a patching method to continue." },
+            this._updateStatusLabel = new Label(),
             new Label { Text = "LittleBigPlanet:" },
             this.PipelineButton<LbpPS3PatchPipeline>("Patch LBP1/2/3 for PS3"),
             this.PipelineButton<PatchworkPS3ConfigPipeline>("Reconfigure Patch for PS3"),
@@ -38,6 +59,69 @@ public class MainForm : RefresherForm
 
         layout.Spacing = 5;
         layout.HorizontalContentAlignment = HorizontalAlignment.Stretch;
+
+        this.UpdateStatus = "Loading updater...";
+    }
+
+    protected override void OnLoadComplete(EventArgs e)
+    {
+        base.OnLoadComplete(e);
+        this.UpdateStatus = "Checking for updates...";
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                await this.CheckForUpdatesAsync();
+            }
+            catch (NotInstalledException)
+            {
+                this.UpdateStatus = "This build of Refresher cannot be updated.";
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to check for updates: {ex}", "Refresher", MessageBoxType.Error);
+            }
+        });
+    }
+
+    private async Task CheckForUpdatesAsync()
+    {
+        UpdateInfo? newVersion = await this._velo.CheckForUpdatesAsync();
+        if (newVersion == null)
+        {
+            this.UpdateStatus = "Refresher is up to date!";
+            return;
+        }
+
+        this.UpdateStatus = "Downloading update...";
+        await this._velo.DownloadUpdatesAsync(newVersion);
+
+        this._updateInfo = newVersion;
+        
+        this.UpdateStatus = $"An update is available. Click here to install Refresher {newVersion.TargetFullRelease.Version.ToNormalizedString()}!";
+        this._updateStatusLabel.TextColor = Colors.Orange;
+        this._updateStatusLabel.MouseUp += this.OnClickUpdate;
+    }
+
+    private void OnClickUpdate(object? sender, MouseEventArgs e)
+    {
+        if (this._updateInfo == null)
+            throw new InvalidOperationException("Cannot install an update if an update is not available");
+
+        this.UpdateStatus = "Installing...";
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                this._velo.ApplyUpdatesAndRestart(this._updateInfo);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to install updates: {ex}", "Refresher", MessageBoxType.Error);
+            }
+        });
     }
 
     private Button PipelineButton<TPipeline>(string name) where TPipeline : Pipeline, new()

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -90,7 +90,7 @@ public class MainForm : RefresherForm
         UpdateInfo? newVersion = await this._velo.CheckForUpdatesAsync();
         if (newVersion == null)
         {
-            this.UpdateStatus = "Refresher is up to date!";
+            this.UpdateStatus = $"Refresher is up to date! {this._velo.CurrentVersion?.ToNormalizedString() ?? "<unknown>"}";
             return;
         }
 
@@ -100,8 +100,11 @@ public class MainForm : RefresherForm
         this._updateInfo = newVersion;
         
         this.UpdateStatus = $"An update is available. Click here to install Refresher {newVersion.TargetFullRelease.Version.ToNormalizedString()}!";
-        this._updateStatusLabel.TextColor = Colors.Orange;
-        this._updateStatusLabel.MouseUp += this.OnClickUpdate;
+        await Application.Instance.InvokeAsync(() =>
+        {
+            this._updateStatusLabel.TextColor = Colors.Orange;
+            this._updateStatusLabel.MouseUp += this.OnClickUpdate;
+        });
     }
 
     private void OnClickUpdate(object? sender, MouseEventArgs e)
@@ -111,7 +114,7 @@ public class MainForm : RefresherForm
 
         this.UpdateStatus = "Installing...";
 
-        Task.Run(async () =>
+        Task.Run(() =>
         {
             try
             {

--- a/Refresher/UI/MainForm.cs
+++ b/Refresher/UI/MainForm.cs
@@ -60,7 +60,7 @@ public class MainForm : RefresherForm
         layout.Spacing = 5;
         layout.HorizontalContentAlignment = HorizontalAlignment.Stretch;
 
-        this.UpdateStatus = "Loading updater...";
+        this._updateStatusLabel.Text = "Loading updater...";
     }
 
     protected override void OnLoadComplete(EventArgs e)
@@ -90,7 +90,7 @@ public class MainForm : RefresherForm
         UpdateInfo? newVersion = await this._velo.CheckForUpdatesAsync();
         if (newVersion == null)
         {
-            this.UpdateStatus = $"Refresher is up to date! {this._velo.CurrentVersion?.ToNormalizedString() ?? "<unknown>"}";
+            this.UpdateStatus = $"Refresher is up to date! You are on v{this._velo.CurrentVersion?.ToNormalizedString() ?? "<unknown>"}.";
             return;
         }
 


### PR DESCRIPTION
Closes #93.

Velopack allows users to automatically check, download, and install updates from the `MainForm` in Refresher. It works off of GitHub Actions and was pretty simple to set up.

Some notes, though:
- Velopack doesn't support an ARM32 runtime, so I've dropped support for `linux-arm` builds.
- I don't want to touch Mac since I can't test it, plus codesigning requirements, so it will use the old release system for now.
- Due to what I think is a bug in `ncipollo/release-action`, the blurb about codesigning in the release isn't automatically added. This will have to be done manually now.
- Windows builds now install to disk if you use the setup program, but a portable option is also still available.
- Linux builds now use AppImage.
- Yes, the git tree is a mess.