### PR TITLE
Catch and log exceptions while trying to load refresher.ico in RefresherForm

### DIFF
--- a/Refresher.Core/LogType.cs
+++ b/Refresher.Core/LogType.cs
@@ -22,4 +22,5 @@ public enum LogType : byte
     Encrypt,
     Decrypt,
     Platform,
+    RefresherForm,
 }

--- a/Refresher/UI/RefresherForm.cs
+++ b/Refresher/UI/RefresherForm.cs
@@ -18,7 +18,15 @@ public abstract class RefresherForm : Form
         // this.AutoSize = true;
         this.Padding = new Padding(10, 10, 10, padBottom ? 10 : 0);
         
-        this.Icon = Icon.FromResource("refresher.ico");
+        try
+        {
+            this.Icon = Icon.FromResource("refresher.ico");
+        }
+        catch (Exception ex)
+        {
+            // Not very important, so this should just be a warning, not an error
+            State.Logger.LogWarning(LogType.RefresherForm, $"Unhandled exception while loading refresher.ico in {this.GetType()}: {ex}");
+        }
         
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             Menu = new RefresherMenuBar();


### PR DESCRIPTION
This should hopefully fix an issue where some people are unable to start Refresher on certain operating systems due to the Refresher icon not being able to load. I can't fully test this myself, but I have taken this log for reference: https://discord.com/channels/1049223665243389953/1262898863774105620/1389972444227436665