### PR TITLE
URL associations for patching and join keys

### DIFF
--- a/Refresher.Core/Pipelines/CommonStepInputs.cs
+++ b/Refresher.Core/Pipelines/CommonStepInputs.cs
@@ -30,7 +30,7 @@ public static class CommonStepInputs
         Required = true,
     };
     
-    internal static readonly StepInput LobbyPassword = new("lobby-password", "Join Key")
+    public static readonly StepInput LobbyPassword = new("lobby-password", "Join Key")
     {
         Placeholder = "(leave empty to randomize)",
     };

--- a/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/LbpPS3PatchPipeline.cs
@@ -11,6 +11,7 @@ public class LbpPS3PatchPipeline : Pipeline
     public override bool ReplacesEboot => true;
 
     public override string GuideLink => "https://docs.littlebigrefresh.com/ps3";
+    public override string? ShorthandUrlId => "ps3";
 
     public override IEnumerable<string> GameNameFilters => ["littlebigplanet", "lbp"];
 

--- a/Refresher.Core/Pipelines/Lbp/LbpRPCS3PatchPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/LbpRPCS3PatchPipeline.cs
@@ -12,6 +12,7 @@ public class LbpRPCS3PatchPipeline : Pipeline
     public override bool ReplacesEboot => true;
 
     public override string GuideLink => "https://docs.littlebigrefresh.com/rpcs3";
+    public override string? ShorthandUrlId => "rpcs3";
 
     public override IEnumerable<string> GameNameFilters => ["littlebigplanet", "lbp"];
 

--- a/Refresher.Core/Pipelines/Lbp/PatchworkConfigPipeline.cs
+++ b/Refresher.Core/Pipelines/Lbp/PatchworkConfigPipeline.cs
@@ -6,7 +6,9 @@ public abstract class PatchworkConfigPipeline : Pipeline
 {
     public override string Id => "patchwork-config-" + this.ConsoleName.ToLower();
     public override string Name => $"Patchwork {this.ConsoleName} Config";
-    
+
+    public override string? ShorthandUrlId => this.ConsoleName.ToLower();
+
     protected abstract string ConsoleName { get; }
 
     protected abstract override Type? SetupAccessorStepType { get; }

--- a/Refresher.Core/Pipelines/Pipeline.cs
+++ b/Refresher.Core/Pipelines/Pipeline.cs
@@ -29,6 +29,7 @@ public abstract class Pipeline : IAccessesPlatform
     public AutoDiscoverResponse? AutoDiscover { get; internal set; }
 
     public virtual string? GuideLink => null;
+    public virtual string? ShorthandUrlId => null;
 
     public virtual IEnumerable<string> GameNameFilters => [];
     

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -117,29 +117,42 @@ public class Program
         string[] urlPath = uri.AbsolutePath.Split('/');
         if (urlPath.Length != 2)
             InvalidUrl(uriStr);
-        string key = uri.Query.TrimStart('?');
+        string value = uri.Query.TrimStart('?');
 
         string method = uri.Host;
         string target = urlPath[1];
         
-        if(string.IsNullOrWhiteSpace(key) && method == "join")
+        if(string.IsNullOrWhiteSpace(value))
             InvalidUrl(uriStr);
 
-        // MessageBox.Show($"method:'{method}'\ntarget:'{target}'\nkey:'{key}'");
+        // MessageBox.Show($"method:'{method}'\ntarget:'{target}'\nvalue:'{value}'");
 
         AutoApplyInformation info = new();
-        info.JoinKey = key;
 
         switch (method)
         {
             case "join":
                 info.AutomaticallyApply = true;
+                info.AutomaticallyDiscover = true;
+                info.JoinKey = value;
                 switch (target)
                 {
                     case "ps3":
                         return new PipelineForm<PatchworkPS3ConfigPipeline>(info);
                     case "rpcs3":
                         return new PipelineForm<PatchworkRPCS3ConfigPipeline>(info);
+                }
+                break;
+            case "patch":
+                info.AutomaticallyApply = false;
+                info.AutomaticallyDiscover = true;
+                info.ServerUrl = value;
+                switch (target)
+                {
+                    case "ps3":
+                        return new PipelineForm<LbpPS3PatchPipeline>(info);
+                    case "rpcs3":
+                        return new PipelineForm<LbpRPCS3PatchPipeline>(info);
                 }
                 break;
             default:

--- a/Refresher/Program.cs
+++ b/Refresher/Program.cs
@@ -28,7 +28,10 @@ public class Program
         State.InitializeLogger([new ConsoleSink(), new EventSink(), new SentryBreadcrumbSink()]);
         State.InitializeSentry();
         
-        if (args.Length > 0)
+        State.Logger.LogInfo(OSIntegration, $"Refresher launched with args [{string.Join(',', args)}] (count: {args.Length})");
+        bool isCliInvocation = args.Length > 0 && !UrlAssociationHandler.IsArgsUrl(args) && !UrlAssociationHandler.IsArgsTryingToRegisterAssociations(args);
+        
+        if (isCliInvocation)
         {
             State.Logger.LogInfo(OSIntegration, "Launching in CLI mode");
             
@@ -69,6 +72,14 @@ public class Program
             // this will NOT work in rider. it must be run independently or the console will be useless
             if (OperatingSystem.IsWindows() && (Keyboard.Modifiers & Keys.Shift) != 0)
                 WindowsConsoleHelper.AllocateConsole();
+            
+            UrlAssociationHandler.RegisterAssociationIfNotPresent();
+
+            if (UrlAssociationHandler.IsArgsTryingToRegisterAssociations(args))
+            {
+                App.Dispose();
+                return;
+            }
             
             try
             {

--- a/Refresher/UI/AutoApplyInformation.cs
+++ b/Refresher/UI/AutoApplyInformation.cs
@@ -1,0 +1,7 @@
+﻿namespace Refresher.UI;
+
+public class AutoApplyInformation
+{
+    public bool AutomaticallyApply;
+    public string? JoinKey;
+}

--- a/Refresher/UI/AutoApplyInformation.cs
+++ b/Refresher/UI/AutoApplyInformation.cs
@@ -3,5 +3,7 @@
 public class AutoApplyInformation
 {
     public bool AutomaticallyApply;
+    public bool AutomaticallyDiscover;
     public string? JoinKey;
+    public string? ServerUrl;
 }

--- a/Refresher/UI/PipelineForm.cs
+++ b/Refresher/UI/PipelineForm.cs
@@ -102,9 +102,11 @@ public class PipelineForm<TPipeline> : RefresherForm, IAccessesPlatform where TP
         if(this._shouldTriggerOnConnect || (this._autoApply?.AutomaticallyApply ?? false))
             this.OnConnect(this, EventArgs.Empty);
 
+        if (this._autoApply?.AutomaticallyDiscover ?? false)
+            this.OnAutoDiscoverClick(null, EventArgs.Empty);
+
         if (this._autoApply?.AutomaticallyApply ?? false)
         {
-            this.OnAutoDiscoverClick(null, EventArgs.Empty);
             new Thread(() =>
             {
                 while (!this._usedAutoDiscover || !this._connected)
@@ -165,6 +167,9 @@ public class PipelineForm<TPipeline> : RefresherForm, IAccessesPlatform where TP
             PreviousInputStorage.StoredInputs.TryGetValue(input.Id, out string? value);
             if (input.Id == CommonStepInputs.LobbyPassword.Id && this._autoApply != null)
                 value = this._autoApply.JoinKey;
+
+            if (input.Id == CommonStepInputs.ServerUrl.Id && this._autoApply != null)
+                value = this._autoApply.ServerUrl;
             
             TableRow row;
             switch (input.Type)

--- a/Refresher/UrlAssociationHandler.cs
+++ b/Refresher/UrlAssociationHandler.cs
@@ -1,0 +1,108 @@
+﻿using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Security.Principal;
+using Eto.Forms;
+using Microsoft.Win32;
+using Velopack;
+using Velopack.Locators;
+
+namespace Refresher;
+
+public static class UrlAssociationHandler
+{
+    private const string Protocol = "refresher";
+    private static readonly string ApplicationPath = string.Empty;
+
+    static UrlAssociationHandler()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            ApplicationPath = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData") ?? throw new UnreachableException(), "Refresher", "current");
+        }
+    }
+
+    public static bool IsArgsUrl(string[] args)
+    {
+        if (args.Length == 0)
+            return false;
+        return args[0].StartsWith(Protocol);
+    }
+
+    public static bool IsArgsTryingToRegisterAssociations(string[] args)
+    {
+        if (args.Length == 0)
+            return false;
+
+        return args[0] == "--register-associations";
+    }
+    
+    [SupportedOSPlatform("windows")]
+    public static bool IsAdministrator()
+    {
+        using WindowsIdentity identity = WindowsIdentity.GetCurrent();
+
+        WindowsPrincipal principal = new(identity);
+        return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    /// <summary>
+    /// Registers the proper registry associations
+    /// </summary>
+    /// <returns>True if the association was created or already present, false if we couldn't create it</returns>
+    [SupportedOSPlatform("windows")]
+    public static bool RegisterAssociationIfNotPresent()
+    {
+        if (!OperatingSystem.IsWindows())
+            return false;
+        
+        if (VelopackLocator.Current.IsPortable)
+            return false;
+
+        RegistryKey? key = Registry.ClassesRoot.OpenSubKey(Protocol);
+        if (key != null)
+            return true;
+
+        if (!IsAdministrator())
+        {
+            const string msg =
+                "Refresher supports URL associations for clickable patch links. Would you like to enable them?\n\n" +
+                "This operation runs once and requires administrator privileges.";
+            
+            DialogResult result = MessageBox.Show(msg, "Refresher", MessageBoxButtons.YesNo, MessageBoxType.Question);
+            if (result == DialogResult.No)
+                return false;
+
+            ElevateToRegisterAssociations();
+
+            MessageBox.Show("Successfully registered!", "Refresher", MessageBoxButtons.OK);
+            return true;
+        }
+
+        key = Registry.ClassesRoot.CreateSubKey(Protocol);
+        key.SetValue("", "URL:Refresher");
+        key.SetValue("URL Protocol", "");
+
+        RegistryKey subKey = key.CreateSubKey(@"Shell\Open\Command");
+        subKey.SetValue("", $"{ApplicationPath} %1");
+        return true;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void ElevateToRegisterAssociations()
+    {
+        ProcessStartInfo info = new(Process.GetCurrentProcess().MainModule?.FileName ?? throw new UnreachableException())
+            {
+                UseShellExecute = true,
+                Verb = "runas",
+                Arguments = "--register-associations",
+            };
+
+        Process? process = Process.Start(info);
+        if (process == null)
+            throw new Exception("Process didn't start");
+
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new Exception("Process exited with code " + process.ExitCode);
+    }
+}

--- a/Refresher/UrlAssociationHandler.cs
+++ b/Refresher/UrlAssociationHandler.cs
@@ -17,7 +17,8 @@ public static class UrlAssociationHandler
     {
         if (OperatingSystem.IsWindows())
         {
-            ApplicationPath = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData") ?? throw new UnreachableException(), "Refresher", "current");
+            ApplicationPath = Process.GetCurrentProcess().MainModule?.FileName ?? throw new UnreachableException();
+            // ApplicationPath = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData") ?? throw new UnreachableException(), "Refresher", "current", "Refresher.exe");
         }
     }
 

--- a/Refresher/UrlAssociationHandler.cs
+++ b/Refresher/UrlAssociationHandler.cs
@@ -17,8 +17,8 @@ public static class UrlAssociationHandler
     {
         if (OperatingSystem.IsWindows())
         {
-            ApplicationPath = Process.GetCurrentProcess().MainModule?.FileName ?? throw new UnreachableException();
-            // ApplicationPath = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData") ?? throw new UnreachableException(), "Refresher", "current", "Refresher.exe");
+            // ApplicationPath = Process.GetCurrentProcess().MainModule?.FileName ?? throw new UnreachableException();
+            ApplicationPath = Path.Combine(Environment.GetEnvironmentVariable("LocalAppData") ?? throw new UnreachableException(), "Refresher", "current", "Refresher.exe");
         }
     }
 


### PR DESCRIPTION
This will only support Windows out of the box for now. Unfortunately due to permission restrictions we have to prompt for admin to install the URL handler, but I've written a quick 'n' dirty prompt to ask the user on startup and it works pretty well.

You can test each operation with this simple HTML page:

```html
<html>
<a href="refresher://join/rpcs3?1234">refresher://join/rpcs3?1234</a>
<br/>
<a href="refresher://join/ps3?1234">refresher://join/ps3?1234</a>

<br/>
<br/>

<a href="refresher://patch/rpcs3?lbp.lbpbonsai.com">refresher://patch/rpcs3?lbp.lbpbonsai.com</a>
<br/>
<a href="refresher://patch/ps3?lbp.lbpbonsai.com">refresher://patch/ps3?lbp.lbpbonsai.com</a>
</html>
```

Join links (refresher://join/console?key) have the unique property of automatically patching once the patcher is ready without waiting. This may backfire, we'll see how it goes. Patch links (refresher://patch/console?domain) don't do this, since it assumes the user needs to fill out the rest of the patcher form first. I plan to introduce this link in guides once it's been out in the wild for a bit.